### PR TITLE
Fix README wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 * Ideal for both local and distributed teams, enhancing team coordination and planning.
 
 ## Technologies
-* Uses Python [FastAPI](https://github.com/tiangolo/fastapi) on the backend and [MongoDB](https://github.com/mongodb/mongo) as a storage.
+* Uses Python [FastAPI](https://github.com/tiangolo/fastapi) on the backend and [MongoDB](https://github.com/mongodb/mongo) as storage.
 * [ReactJS](https://github.com/facebook/react) on the frontend.
 
 ## Screenshot


### PR DESCRIPTION
## Summary
- fix minor grammar: `as a storage` -> `as storage`
- ensure newline at EOF for README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bson')*

------
https://chatgpt.com/codex/tasks/task_e_68420a96f350832097987b9cdd4d1552