### PR TITLE
Add loading spinner

### DIFF
--- a/frontend/src/components/MainComponent.css
+++ b/frontend/src/components/MainComponent.css
@@ -42,6 +42,33 @@
     opacity: 1;
 }
 
+.spinner {
+    border: 4px solid #f3f3f3;
+    border-top: 4px solid #4DB4D7; /* Match primary accent */
+    border-radius: 50%;
+    width: 20px;
+    height: 20px;
+    animation: spin 1s linear infinite;
+}
+
+.spinner.large {
+    width: 40px;
+    height: 40px;
+    border-width: 6px;
+}
+
+@keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+.initial-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+}
+
 .userIcon {
     /*width: 30px; !* Adjust size as needed *!*/
     /*height: 30px; !* Adjust size as needed *!*/

--- a/frontend/src/components/MainComponent.jsx
+++ b/frontend/src/components/MainComponent.jsx
@@ -87,12 +87,16 @@ const MainComponent = () => {
         }
     };
 
-    if (!data) return <div>Loading...</div>;
+    if (!data) return (
+        <div className="initial-loading">
+            <div className="spinner large" role="status" aria-label="Loading" />
+        </div>
+    );
 
     return (
         <div className="mainContainer">
             <div className="loadingIndicator">
-                {isLoading && 'Loading...'}
+                {isLoading && <div className="spinner" role="status" aria-label="Loading" />}
             </div>
             <div className="iconContainer">
                 <div className="reportIcon" onClick={openReportModal} title="Generate Report">


### PR DESCRIPTION
## Summary
- show a spinner while fetching data
- provide centered spinner when initializing the app

## Testing
- `npm install`
- `npm test --silent -- --watchAll=false` *(fails: Cannot destructure property 'isAuthenticated' of 'useAuth' as it is undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6868d873ba048320b0b8d4e54afd8c0a