### PR TITLE
Fix login after initial workspace creation

### DIFF
--- a/frontend/src/components/auth/InitialUserCreation.jsx
+++ b/frontend/src/components/auth/InitialUserCreation.jsx
@@ -3,10 +3,12 @@ import {useNavigate} from 'react-router-dom';
 import {useApi} from '../../hooks/useApi';
 import {toast} from "react-toastify";
 import './InitialUserCreation.css';
+import {useConfig} from "../../contexts/ConfigContext";
 
 const InitialUserCreation = () => {
   const navigate = useNavigate();
   const {apiCall} = useApi();
+  const {setUserInitiated} = useConfig();
   const [tenantName, setTenantName] = useState('');
   const [tenantIdentifier, setTenantIdentifier] = useState('');
   const [name, setName] = useState('');
@@ -19,6 +21,7 @@ const InitialUserCreation = () => {
     const tenant = {name: tenantName, identifier: tenantIdentifier};
     try {
       await apiCall('/users/create-initial', 'POST', {tenant, name, email, username, password});
+      setUserInitiated(true);
       navigate('/login');
     } catch (error) {
       console.error('Error creating initial user:', error);

--- a/frontend/src/contexts/ConfigContext.js
+++ b/frontend/src/contexts/ConfigContext.js
@@ -37,6 +37,7 @@ export const ConfigProvider = ({children}) => {
         isTelegramEnabled,
         telegramBotUsername,
         userInitiated,
+        setUserInitiated,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary
- expose `setUserInitiated` through `ConfigContext`
- update the context after creating the first user so the login page loads

## Testing
- `npm test -- --watchAll=false` *(fails: TypeError in App.test.js)*
- `pytest -q` *(fails: missing httpx and MongoDB connection)*

------
https://chatgpt.com/codex/tasks/task_e_68694a72468883208cfd904ddf4b6352