### PR TITLE
Add password reset via email

### DIFF
--- a/backend/model.py
+++ b/backend/model.py
@@ -224,6 +224,30 @@ class UserInvite(Document):
         self.save()
 
 
+class PasswordResetToken(Document):
+    user = ReferenceField(User, required=True)
+    token = StringField(required=True, unique=True)
+    status = StringField(choices=["pending", "used", "expired"], default="pending")
+    expiration_date = DateTimeField(default=lambda: datetime.now(timezone.utc) + timedelta(hours=1))
+
+    meta = {
+        "indexes": [
+            "user",
+            "token",
+            "status",
+        ],
+        "index_background": True
+    }
+
+    def is_expired(self):
+        self.expiration_date = self.expiration_date.replace(tzinfo=timezone.utc)
+        return datetime.now(timezone.utc) > self.expiration_date
+
+    def mark_as_used(self):
+        self.status = "used"
+        self.save()
+
+
 def generate_random_hex_color():
     """Generate a random hex color code."""
     return "#{:06x}".format(random.randint(0, 0xFFFFFF))

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -8,6 +8,8 @@ import UserRegistration from "./components/auth/UserRegistration";
 import './styles.css';
 import {useAuth} from './contexts/AuthContext';
 import AdditionalWorkspaceCreation from "./components/auth/AdditionalWorkspaceCreation";
+import PasswordResetRequest from "./components/auth/PasswordResetRequest";
+import PasswordReset from "./components/auth/PasswordReset";
 
 
 function App() {
@@ -22,6 +24,8 @@ function App() {
             <Navigate to="/main"/>
         }/>
         <Route path="/login" element={<Login/>}/>
+        <Route path="/password-reset-request" element={<PasswordResetRequest/>}/>
+        <Route path="/password-reset/:token" element={<PasswordReset/>}/>
         <Route path="/create-initial-user" element={<InitialUserCreation/>}/>
         <Route path="/register/:token" element={<UserRegistration/>}/>
         <Route path="/create-additional-workspace" element={<AdditionalWorkspaceCreation/>}/>

--- a/frontend/src/components/auth/Login.css
+++ b/frontend/src/components/auth/Login.css
@@ -68,7 +68,13 @@ h3 {
 
 .forgotPasswordLink {
     margin-top: 10px;
-    cursor: pointer;
+    align-self: flex-end;
+    font-size: 0.9em;
     color: #007bff;
+    cursor: pointer;
+    text-decoration: none;
+}
+
+.forgotPasswordLink:hover {
     text-decoration: underline;
 }

--- a/frontend/src/components/auth/Login.css
+++ b/frontend/src/components/auth/Login.css
@@ -68,7 +68,8 @@ h3 {
 
 .forgotPasswordLink {
     margin-top: 10px;
-    align-self: flex-end;
+    align-self: center;
+    text-align: center;
     font-size: 0.9em;
     color: #007bff;
     cursor: pointer;

--- a/frontend/src/components/auth/Login.css
+++ b/frontend/src/components/auth/Login.css
@@ -65,3 +65,10 @@ h3 {
 .signUpButton:hover {
     background-color: #0056b3;
 }
+
+.forgotPasswordLink {
+    margin-top: 10px;
+    cursor: pointer;
+    color: #007bff;
+    text-decoration: underline;
+}

--- a/frontend/src/components/auth/Login.jsx
+++ b/frontend/src/components/auth/Login.jsx
@@ -57,6 +57,7 @@ const Login = () => {
           />
           <button type="submit" className="buttonStyle">Log in</button>
         </form>
+        <p style={{cursor: 'pointer', marginTop: '10px'}} onClick={() => navigate('/password-reset-request')}>Forgot password?</p>
         {isTelegramEnabled && <TelegramLogin telegramBotUsername={telegramBotUsername}/>}
       </div>
     </div>

--- a/frontend/src/components/auth/Login.jsx
+++ b/frontend/src/components/auth/Login.jsx
@@ -56,8 +56,13 @@ const Login = () => {
             className="inputStyle"
           />
           <button type="submit" className="buttonStyle">Log in</button>
+          <p
+            className="forgotPasswordLink"
+            onClick={() => navigate('/password-reset-request')}
+          >
+            Forgot password?
+          </p>
         </form>
-        <p style={{cursor: 'pointer', marginTop: '10px'}} onClick={() => navigate('/password-reset-request')}>Forgot password?</p>
         {isTelegramEnabled && <TelegramLogin telegramBotUsername={telegramBotUsername}/>}
       </div>
     </div>

--- a/frontend/src/components/auth/PasswordReset.jsx
+++ b/frontend/src/components/auth/PasswordReset.jsx
@@ -1,0 +1,45 @@
+import React, {useState} from 'react';
+import {useParams, useNavigate} from 'react-router-dom';
+import {useApi} from '../../hooks/useApi';
+import {toast} from 'react-toastify';
+import './InitialUserCreation.css';
+
+const PasswordReset = () => {
+  const {token} = useParams();
+  const {apiCall} = useApi();
+  const navigate = useNavigate();
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await apiCall(`/users/password-reset/${token}`, 'POST', {
+        new_password: newPassword,
+        confirm_password: confirmPassword,
+      });
+      toast.success('Password reset successfully');
+      navigate('/login');
+    } catch (error) {
+      if (error.data && error.data.detail) {
+        toast.error(error.data.detail);
+      } else {
+        toast.error('An error occurred. Please try again.');
+      }
+    }
+  };
+
+  return (
+    <div className="initialUserCreationContainer">
+      <h1>Set New Password</h1>
+      <button className="logInButton" onClick={() => navigate('/login')}>Log in</button>
+      <form onSubmit={handleSubmit} className="formStyle">
+        <input type="password" name="new-password" autoComplete="new-password" value={newPassword} onChange={(e)=>setNewPassword(e.target.value)} placeholder="New password" className="inputStyle" required autoFocus />
+        <input type="password" name="confirm-password" autoComplete="new-password" value={confirmPassword} onChange={(e)=>setConfirmPassword(e.target.value)} placeholder="Confirm password" className="inputStyle" required />
+        <button type="submit" className="buttonStyle createWorkspaceButton">Reset Password</button>
+      </form>
+    </div>
+  );
+};
+
+export default PasswordReset;

--- a/frontend/src/components/auth/PasswordResetRequest.jsx
+++ b/frontend/src/components/auth/PasswordResetRequest.jsx
@@ -1,0 +1,40 @@
+import React, {useState} from 'react';
+import {useNavigate} from 'react-router-dom';
+import {useApi} from '../../hooks/useApi';
+import {toast} from 'react-toastify';
+import './Login.css';
+
+const PasswordResetRequest = () => {
+  const {apiCall} = useApi();
+  const [email, setEmail] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await apiCall('/users/password-reset/request', 'POST', {email});
+      toast.success('Password reset email sent');
+      navigate('/login');
+    } catch (error) {
+      if (error.data && error.data.detail) {
+        toast.error(error.data.detail);
+      } else {
+        toast.error('An error occurred. Please try again.');
+      }
+    }
+  };
+
+  return (
+    <div className="loginContainer">
+      <div className="loginCenter">
+        <h1>Reset Password</h1>
+        <form onSubmit={handleSubmit} className="formStyle">
+          <input type="email" value={email} onChange={(e)=>setEmail(e.target.value)} placeholder="Email" className="inputStyle" required autoFocus />
+          <button type="submit" className="buttonStyle">Send reset link</button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default PasswordResetRequest;


### PR DESCRIPTION
## Summary
- allow users to request password reset
- send email with reset link
- update backend models and routes
- add frontend pages for requesting and completing reset
- link to reset from login page

## Testing
- `pytest -q backend/test_main.py` *(fails: ServerSelectionTimeoutError)*

------
https://chatgpt.com/codex/tasks/task_e_686954611ba483208b4eb8e3b51b1688