### PR TITLE
Add return-to-login button on password reset request page

### DIFF
--- a/frontend/src/components/auth/PasswordResetRequest.jsx
+++ b/frontend/src/components/auth/PasswordResetRequest.jsx
@@ -3,6 +3,7 @@ import {useNavigate} from 'react-router-dom';
 import {useApi} from '../../hooks/useApi';
 import {toast} from 'react-toastify';
 import './Login.css';
+import './InitialUserCreation.css';
 
 const PasswordResetRequest = () => {
   const {apiCall} = useApi();
@@ -26,10 +27,21 @@ const PasswordResetRequest = () => {
 
   return (
     <div className="loginContainer">
+      <button className="logInButton" onClick={() => navigate('/login')}>
+        Log in
+      </button>
       <div className="loginCenter">
         <h1>Reset Password</h1>
         <form onSubmit={handleSubmit} className="formStyle">
-          <input type="email" value={email} onChange={(e)=>setEmail(e.target.value)} placeholder="Email" className="inputStyle" required autoFocus />
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="Email"
+            className="inputStyle"
+            required
+            autoFocus
+          />
           <button type="submit" className="buttonStyle">Send reset link</button>
         </form>
       </div>


### PR DESCRIPTION
## Summary
- allow returning to login from the password reset request screen

## Testing
- `./run_pytest_docker_compose_local.sh` *(fails: docker-compose not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869675a7a70832083b65da3840708ad