### PR TITLE
Enable backend tests without MongoDB

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,2 +1,16 @@
 ## Automatic testing
 Run backend tests only in case there were backend changes.
+
+### Running tests locally
+The test suite uses an in-memory MongoDB when the `MONGO_MOCK` environment
+variable is set. The test files set this variable automatically, so running the
+tests is as simple as:
+
+```
+pip install -r backend/requirements.txt
+pip install httpx  # required by FastAPI TestClient
+pytest backend
+```
+
+If running tests manually, ensure `AUTHENTICATION_SECRET_KEY` is defined (any
+value is fine) and `MONGO_MOCK=1` so that the real database is not required.

--- a/backend/db_migrations/db_utils.py
+++ b/backend/db_migrations/db_utils.py
@@ -2,6 +2,7 @@ import os
 
 from dotenv import load_dotenv
 from pymongo import MongoClient
+import mongomock
 
 # in production the environments should be set and not loaded from .env
 load_dotenv()  # mostly for local development with docker-compose
@@ -12,8 +13,11 @@ mongo_host = os.getenv("MONGO_HOST")
 mongo_port = os.getenv("MONGO_PORT")
 mongo_db_name = os.getenv("MONGO_DB_NAME", "vacal")
 mongo_uri = os.getenv("MONGO_URI")
+use_mock = os.getenv("MONGO_MOCK")
 
-if mongo_uri:
+if use_mock:
+    client = mongomock.MongoClient()
+elif mongo_uri:
     if mongo_uri.startswith('"') and mongo_uri.endswith('"'):
         mongo_uri = mongo_uri.strip('"')
     client = MongoClient(mongo_uri)

--- a/backend/model.py
+++ b/backend/model.py
@@ -10,6 +10,7 @@ from dotenv import load_dotenv
 from mongoengine import StringField, ListField, connect, Document, EmbeddedDocument, \
     EmbeddedDocumentListField, UUIDField, EmailField, ReferenceField, MapField, EmbeddedDocumentField, BooleanField, \
     LongField, DateTimeField, IntField, DateField, DecimalField
+import mongomock
 from passlib.context import CryptContext
 from pymongo import MongoClient
 
@@ -28,8 +29,12 @@ mongo_host = os.getenv("MONGO_HOST")
 mongo_port = os.getenv("MONGO_PORT")
 mongo_db_name = os.getenv("MONGO_DB_NAME")
 mongo_uri = os.getenv("MONGO_URI")
+use_mock = os.getenv("MONGO_MOCK")
 
-if mongo_uri:
+if use_mock:
+    log.info("Using mongomock for MongoDB connection")
+    connect(mongo_db_name or "vacal", mongo_client_class=mongomock.MongoClient)
+elif mongo_uri:
     if mongo_uri.startswith('"') and mongo_uri.endswith('"'):
         mongo_uri = mongo_uri.strip('"')
     connect(mongo_db_name, host=mongo_uri)
@@ -352,4 +357,5 @@ def calculate_team_members_number_in_tenant(tenant):
     return team_member_count
 
 
-run_migrations()
+if not use_mock:
+    run_migrations()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,4 @@ python-multipart
 passlib[bcrypt]
 pyjwt
 python-dateutil
+mongomock

--- a/backend/routers/test_users.py
+++ b/backend/routers/test_users.py
@@ -1,4 +1,9 @@
 from unittest.mock import patch
+import os
+
+# Use in-memory MongoDB for tests
+os.environ.setdefault("MONGO_MOCK", "1")
+os.environ.setdefault("AUTHENTICATION_SECRET_KEY", "test_secret")
 
 import pytest
 from bson.objectid import ObjectId

--- a/backend/scheduled/test_vacation_starts.py
+++ b/backend/scheduled/test_vacation_starts.py
@@ -1,5 +1,10 @@
 import datetime
 from unittest.mock import MagicMock
+import os
+
+# Use in-memory MongoDB for tests
+os.environ.setdefault("MONGO_MOCK", "1")
+os.environ.setdefault("AUTHENTICATION_SECRET_KEY", "test_secret")
 
 from .vacation_starts import get_next_working_day, only_for_team_member
 

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -1,4 +1,9 @@
 from unittest.mock import patch
+import os
+
+# Use an in-memory MongoDB for tests
+os.environ.setdefault("MONGO_MOCK", "1")
+os.environ.setdefault("AUTHENTICATION_SECRET_KEY", "test_secret")
 
 from fastapi.testclient import TestClient
 from .main import app


### PR DESCRIPTION
## Summary
- use `mongomock` when `MONGO_MOCK` is set
- skip migrations in test mode
- support mock MongoDB in migration utils
- add missing test requirements
- configure tests to use in-memory MongoDB and a dummy secret key
- remove `httpx` from runtime requirements
- document how to run backend tests

## Testing
- `pip install -r backend/requirements.txt`
- `pip install httpx`
- `pytest backend`


------
https://chatgpt.com/codex/tasks/task_e_686a2006281883209fd1ff80750f5f1c