### PR TITLE
Expose read-only calendar feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,10 @@
 * See https://core.telegram.org/widgets/login
 * Configure TELEGRAM_BOT_TOKEN and TELEGRAM_BOT_USERNAME in the backend .env
 * Tip for local testing: https://stackoverflow.com/questions/61964889/testing-telegram-login-widget-locally
+
+### Calendar integration
+Teams expose a read-only iCalendar feed. A token is generated automatically
+for each new team. Regenerate it via `POST /teams/{team_id}/calendar-token`
+and subscribe to `/calendar/{calendar_token}` in external calendars like
+Google Calendar. The feed returns all stored absences, so no dates need to
+be provided in the subscription URL.

--- a/backend/db_migrations/m2025_07_09_001_generate_calendar_tokens.py
+++ b/backend/db_migrations/m2025_07_09_001_generate_calendar_tokens.py
@@ -1,0 +1,13 @@
+from .db_utils import db
+import secrets
+
+team_collection = db['team']
+
+for team in team_collection.find():
+    token = team.get('calendar_token')
+    if not token:
+        new_token = secrets.token_urlsafe(16)
+        team_collection.update_one({'_id': team['_id']}, {'$set': {'calendar_token': new_token}})
+        print(f"Set calendar_token for team {team['_id']}")
+
+print("Migration completed successfully.")

--- a/backend/model.py
+++ b/backend/model.py
@@ -3,6 +3,7 @@ import os
 import random
 import uuid
 from datetime import datetime, timezone, timedelta
+import secrets
 
 import mongoengine
 from dateutil.relativedelta import relativedelta
@@ -317,6 +318,10 @@ class Team(Document):
     team_members = EmbeddedDocumentListField(TeamMember)
     available_day_types = ListField(ReferenceField(DayType))
     subscribers = ListField(ReferenceField(User))
+    # Unique token used for unauthenticated calendar feeds.
+    # `sparse=True` allows multiple documents with a null or empty value.
+    calendar_token = StringField(unique=True, sparse=True,
+                                 default=lambda: secrets.token_urlsafe(16))
 
     meta = {
         "indexes": [

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,3 +15,4 @@ passlib[bcrypt]
 pyjwt
 python-dateutil
 mongomock
+ics

--- a/backend/test_calendar.py
+++ b/backend/test_calendar.py
@@ -1,0 +1,30 @@
+import os
+os.environ.setdefault("MONGO_MOCK", "1")
+os.environ.setdefault("AUTHENTICATION_SECRET_KEY", "test_secret")
+
+from fastapi.testclient import TestClient
+from .main import app
+from .model import Tenant, DayType, Team, TeamMember, DayEntry
+
+client = TestClient(app)
+
+
+def setup_team():
+    tenant = Tenant(name="Test Tenant", identifier="test").save()
+    DayType.init_day_types(tenant)
+    vacation = DayType.objects(tenant=tenant, identifier="vacation").first()
+    member = TeamMember(name="Alice", country="Sweden", days={"2025-01-01": DayEntry(day_types=[vacation])})
+    team = Team(tenant=tenant, name="Team", team_members=[member], calendar_token="tok123")
+    team.save()
+    return team
+
+
+def test_calendar_feed_deterministic():
+    setup_team()
+    resp1 = client.get("/calendar/tok123")
+    resp2 = client.get("/calendar/tok123")
+    assert resp1.status_code == 200
+    assert resp1.status_code == resp2.status_code
+    assert resp1.text == resp2.text
+    assert "BEGIN:VEVENT" in resp1.text
+    assert "VALUE=DATE" in resp1.text

--- a/frontend/src/components/CalendarComponent.css
+++ b/frontend/src/components/CalendarComponent.css
@@ -129,6 +129,7 @@
 /* Hide icons by default */
 .team-name-cell .edit-icon,
 .team-name-cell .delete-icon,
+.team-name-cell .calendar-link-icon,
 .member-name-cell .drag-icon,
 .member-name-cell .edit-icon,
 .member-name-cell .delete-icon,
@@ -139,6 +140,7 @@
 /* Show icons on hover of the cell */
 .team-name-cell:hover .edit-icon,
 .team-name-cell:hover .delete-icon,
+.team-name-cell:hover .calendar-link-icon,
 .member-name-cell:hover .drag-icon,
 .member-name-cell:hover .edit-icon,
 .member-name-cell:hover .delete-icon,
@@ -157,6 +159,12 @@
 }
 
 .add-icon {
+    cursor: pointer;
+    margin-left: 10px;
+    color: #0000ff;
+}
+
+.calendar-link-icon {
     cursor: pointer;
     margin-left: 10px;
     color: #0000ff;

--- a/frontend/src/components/CalendarComponent.css
+++ b/frontend/src/components/CalendarComponent.css
@@ -167,7 +167,7 @@
 .calendar-link-icon {
     cursor: pointer;
     margin-left: 10px;
-    color: #0000ff;
+    color: inherit;
 }
 
 .collapse-icon {

--- a/frontend/src/components/CalendarComponent.jsx
+++ b/frontend/src/components/CalendarComponent.jsx
@@ -9,8 +9,10 @@ import {
   faGripVertical,
   faInfoCircle,
   faSave,
-  faTrashAlt
+  faTrashAlt,
+  faLink
 } from '@fortawesome/free-solid-svg-icons';
+import {toast} from 'react-toastify';
 import './CalendarComponent.css';
 import MonthSelector from './MonthSelector';
 import TeamModal from './TeamModal';
@@ -387,6 +389,15 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
     setFocusedTeamId(prev => (prev === teamId ? null : teamId));
   };
 
+  const handleCopyCalendarLink = (token) => {
+    const link = `${process.env.REACT_APP_API_URL}/calendar/${token}`;
+    navigator.clipboard.writeText(link).then(() => {
+      toast.success('Calendar link copied');
+    }).catch(() => {
+      toast.error('Failed to copy link');
+    });
+  };
+
   const renderVacationDaysTooltip = (member) => {
     const selectedYear = displayMonth.getFullYear();
     const vacationDays = member.vacation_days_by_year[selectedYear];
@@ -622,6 +633,10 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
                       {team.name}
                       <span className="add-icon" onClick={() => handleAddMemberIconClick(team._id)}
                             title="Add team member">➕</span>
+                      <span className="calendar-link-icon" onClick={() => handleCopyCalendarLink(team.calendar_token)}
+                            title="Copy calendar feed link">
+                          <FontAwesomeIcon icon={faLink}/>
+                      </span>
                       <span className="edit-icon" onClick={() => handleEditTeamClick(team._id)}>
                           <FontAwesomeIcon icon={faEdit}/>
                       </span>

--- a/frontend/src/components/CalendarComponent.jsx
+++ b/frontend/src/components/CalendarComponent.jsx
@@ -633,12 +633,12 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
                       {team.name}
                       <span className="add-icon" onClick={() => handleAddMemberIconClick(team._id)}
                             title="Add team member">➕</span>
+                      <span className="edit-icon" onClick={() => handleEditTeamClick(team._id)}>
+                          <FontAwesomeIcon icon={faEdit}/>
+                      </span>
                       <span className="calendar-link-icon" onClick={() => handleCopyCalendarLink(team.calendar_token)}
                             title="Copy calendar feed link">
                           <FontAwesomeIcon icon={faLink}/>
-                      </span>
-                      <span className="edit-icon" onClick={() => handleEditTeamClick(team._id)}>
-                          <FontAwesomeIcon icon={faEdit}/>
                       </span>
                       {team.team_members.length === 0 && (
                         <span className="delete-icon" onClick={() => deleteTeam(team._id)}>


### PR DESCRIPTION
## Summary
- generate calendar token when creating a team
- expose `/calendar/{calendar_token}` for iCalendar feeds
- remove old authenticated calendar export
- document token usage in README
- ensure feed uses stable event UIDs for subscriptions
- remove unused date parameters so feeds don't rely on manual input
- make calendar events all-day with deterministic ordering
- copyable calendar link next to team actions in UI
- create migration to add tokens for existing teams
- ensure calendar feed endpoint validates token
- generate calendar token through default field value

## Testing
- `pytest backend`


------
https://chatgpt.com/codex/tasks/task_e_686d230c5ecc8320b21672ee9d78ad0e