### PR TITLE
Add backend PR test workflow

### DIFF
--- a/.github/workflows/backend_pr_tests.yml
+++ b/.github/workflows/backend_pr_tests.yml
@@ -1,0 +1,37 @@
+name: Backend - Test Pull Requests
+
+on:
+  pull_request:
+    paths:
+      - 'backend/**'
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    services:
+      mongodb:
+        image: mongo:latest
+        ports:
+          - 27017:27017
+
+    steps:
+    - name: Check out the repo
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+        cache: 'pip'
+
+    - name: Install dependencies
+      run: |
+        pip install -U -r backend/requirements.txt
+        pip install pytest httpx
+
+    - name: Run tests with pytest
+      run: pytest backend
+      env:
+        MONGO_MOCK: false
+        AUTHENTICATION_SECRET_KEY: b461cb38030c172d3feb5275e3d841087951b8fe88ad9c1697eb5ee41269a135

--- a/.github/workflows/docker_backend_build.yml
+++ b/.github/workflows/docker_backend_build.yml
@@ -32,8 +32,9 @@ jobs:
         pip install pytest httpx
 
     - name: Run tests with pytest
-      run: pytest
+      run: pytest backend
       env:
+        MONGO_MOCK: false
         AUTHENTICATION_SECRET_KEY: b461cb38030c172d3feb5275e3d841087951b8fe88ad9c1697eb5ee41269a135
 
     - name: Extract the short SHA of the commit

--- a/backend/db_migrations/db_utils.py
+++ b/backend/db_migrations/db_utils.py
@@ -13,7 +13,8 @@ mongo_host = os.getenv("MONGO_HOST")
 mongo_port = os.getenv("MONGO_PORT")
 mongo_db_name = os.getenv("MONGO_DB_NAME", "vacal")
 mongo_uri = os.getenv("MONGO_URI")
-use_mock = os.getenv("MONGO_MOCK")
+use_mock_env = os.getenv("MONGO_MOCK")
+use_mock = str(use_mock_env).lower() in ("1", "true", "yes")
 
 if use_mock:
     client = mongomock.MongoClient()

--- a/backend/model.py
+++ b/backend/model.py
@@ -30,7 +30,8 @@ mongo_host = os.getenv("MONGO_HOST")
 mongo_port = os.getenv("MONGO_PORT")
 mongo_db_name = os.getenv("MONGO_DB_NAME")
 mongo_uri = os.getenv("MONGO_URI")
-use_mock = os.getenv("MONGO_MOCK")
+use_mock_env = os.getenv("MONGO_MOCK")
+use_mock = str(use_mock_env).lower() in ("1", "true", "yes")
 
 if use_mock:
     log.info("Using mongomock for MongoDB connection")


### PR DESCRIPTION
## Summary
- run backend tests on pull requests
- update docker build and PR workflows to use real MongoDB
- allow `MONGO_MOCK=false` to disable Mongo mock

## Testing
- `pytest backend`
- `MONGO_MOCK=false pytest backend` *(fails: ServerSelectionTimeoutError)*

------
https://chatgpt.com/codex/tasks/task_e_686fde2299308320a10d762f917a73ed