### PR TITLE
Track used and planned vacation days

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -155,15 +155,12 @@ class TeamMemberReadDTO(TeamMemberWriteDTO):
     @computed_field
     @property
     def vacation_days_by_year(self) -> Dict[int, int]:
-        vac_days_count = defaultdict(int)
-        vacation_day_type = mongo_to_pydantic(DayType.objects(tenant=tenant_var.get(), name="Vacation").first(),
-                                              DayTypeReadDTO)
-        for date_str, day_entry in self.days.items():
-            date = datetime.datetime.strptime(date_str, "%Y-%m-%d").date()
-            day_types = day_entry.day_types
-            if vacation_day_type in day_types:
-                vac_days_count[date.year] += 1
-        return dict(vac_days_count)
+        """Return total vacation days (used + planned) grouped by year."""
+        used, planned = self._split_vacation_days()
+        totals = defaultdict(int, used)
+        for year, count in planned.items():
+            totals[year] += count
+        return dict(totals)
 
     def _split_vacation_days(self) -> tuple[Dict[int, int], Dict[int, int]]:
         """Return two dicts: used days and planned days by year."""

--- a/backend/main.py
+++ b/backend/main.py
@@ -152,16 +152,6 @@ class TeamMemberReadDTO(TeamMemberWriteDTO):
     days: Dict[str, DayEntryDTO] = Field(default_factory=dict)
     _vacation_split_cache: Optional[Tuple[Dict[int, int], Dict[int, int]]] = PrivateAttr(default=None)
 
-    @computed_field
-    @property
-    def vacation_days_by_year(self) -> Dict[int, int]:
-        """Return total vacation days (used + planned) grouped by year."""
-        used, planned = self._split_vacation_days()
-        totals = defaultdict(int, used)
-        for year, count in planned.items():
-            totals[year] += count
-        return dict(totals)
-
     def _split_vacation_days(self) -> tuple[Dict[int, int], Dict[int, int]]:
         """Return two dicts: used days and planned days by year."""
         if self._vacation_split_cache is not None:

--- a/frontend/src/components/CalendarComponent.jsx
+++ b/frontend/src/components/CalendarComponent.jsx
@@ -400,6 +400,7 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
 
   const renderVacationDaysTooltip = (member) => {
     const selectedYear = displayMonth.getFullYear();
+    const currentYear = new Date().getFullYear();
     const usedDays = member.vacation_used_days_by_year?.[selectedYear] || 0;
     const plannedDays = member.vacation_planned_days_by_year?.[selectedYear] || 0;
     const yearlyVacationDays = member.yearly_vacation_days;
@@ -412,7 +413,16 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
     const yearlyVacationDaysText = yearlyVacationDays
       ? `${yearlyVacationDays} vacation days available per year`
       : 'No yearly vacation days defined';
-    return `${usedText}\n${plannedText}\n${yearlyVacationDaysText}`;
+    let lines = [];
+    if (selectedYear < currentYear) {
+      lines.push(usedText);
+    } else if (selectedYear > currentYear) {
+      lines.push(plannedText);
+    } else {
+      lines.push(usedText, plannedText);
+    }
+    lines.push(yearlyVacationDaysText);
+    return lines.join('\n');
   };
 
   function generateGradientStyle(dateDayTypes) {

--- a/frontend/src/components/CalendarComponent.jsx
+++ b/frontend/src/components/CalendarComponent.jsx
@@ -400,15 +400,19 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
 
   const renderVacationDaysTooltip = (member) => {
     const selectedYear = displayMonth.getFullYear();
-    const vacationDays = member.vacation_days_by_year[selectedYear];
+    const usedDays = member.vacation_used_days_by_year?.[selectedYear] || 0;
+    const plannedDays = member.vacation_planned_days_by_year?.[selectedYear] || 0;
     const yearlyVacationDays = member.yearly_vacation_days;
-    const vacationDaysText = vacationDays
-      ? `${vacationDays} vacation days used in ${selectedYear}`
+    const usedText = usedDays
+      ? `${usedDays} vacation days used in ${selectedYear}`
       : `No vacation days used in ${selectedYear}`;
+    const plannedText = plannedDays
+      ? `${plannedDays} vacation days planned in ${selectedYear}`
+      : `No vacation days planned in ${selectedYear}`;
     const yearlyVacationDaysText = yearlyVacationDays
       ? `${yearlyVacationDays} vacation days available per year`
       : 'No yearly vacation days defined';
-    return `${vacationDaysText}\n${yearlyVacationDaysText}`;
+    return `${usedText}\n${plannedText}\n${yearlyVacationDaysText}`;
   };
 
   function generateGradientStyle(dateDayTypes) {


### PR DESCRIPTION
## Summary
- compute used vs planned vacation days per year in the backend
- show used and planned days separately in calendar tooltips
- cache vacation day split calculations

## Testing
- `pytest backend`


------
https://chatgpt.com/codex/tasks/task_e_686fdcf82ab083208f19e4dc34a5ea90