### PR TITLE
Add vacation availability tracking

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -23,6 +23,11 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse, StreamingResponse, Response
 from fastapi.security import OAuth2PasswordRequestForm
 from ics import Calendar, Event
+
+
+def get_today() -> datetime.date:
+    """Helper to return today's date. Extracted for easier testing."""
+    return datetime.date.today()
 from openpyxl import Workbook
 from openpyxl.utils import get_column_letter
 from prometheus_fastapi_instrumentator import Instrumentator
@@ -163,7 +168,7 @@ class TeamMemberReadDTO(TeamMemberWriteDTO):
             DayType.objects(tenant=tenant_var.get(), name="Vacation").first(),
             DayTypeReadDTO,
         )
-        today = datetime.date.today()
+        today = get_today()
         for date_str, day_entry in self.days.items():
             date = datetime.datetime.strptime(date_str, "%Y-%m-%d").date()
             day_types = day_entry.day_types
@@ -187,6 +192,32 @@ class TeamMemberReadDTO(TeamMemberWriteDTO):
     def vacation_planned_days_by_year(self) -> Dict[int, int]:
         _, planned = self._split_vacation_days()
         return planned
+
+    @computed_field
+    @property
+    def vacation_available_days(self) -> int | None:
+        if self.yearly_vacation_days is None or self.employee_start_date is None:
+            return None
+
+        yearly = Decimal(str(self.yearly_vacation_days))
+        start = self.employee_start_date
+        today = get_today()
+
+        total_budget = Decimal("0")
+        for year in range(start.year, today.year + 1):
+            if year == start.year:
+                days_in_year = (datetime.date(year, 12, 31) - datetime.date(year, 1, 1)).days + 1
+                days_employed = (datetime.date(year, 12, 31) - start).days + 1
+                portion = (Decimal(days_employed) / Decimal(days_in_year)) * yearly
+                total_budget += portion
+            else:
+                total_budget += yearly
+
+        used_total = sum(self.vacation_used_days_by_year.values())
+        planned_total = sum(self.vacation_planned_days_by_year.values())
+
+        available = int(total_budget - used_total - planned_total)
+        return max(0, available)
 
     @model_validator(mode='after')
     def include_birthday(self) -> Self:

--- a/backend/test_vacation_days_available.py
+++ b/backend/test_vacation_days_available.py
@@ -1,0 +1,53 @@
+import os
+os.environ.setdefault("MONGO_MOCK", "1")
+os.environ.setdefault("AUTHENTICATION_SECRET_KEY", "test_secret")
+
+import datetime
+from unittest.mock import patch
+
+from backend.model import Tenant, DayType, TeamMember, DayEntry
+from backend.dependencies import mongo_to_pydantic, tenant_var
+from backend.main import TeamMemberReadDTO
+import uuid
+
+
+def setup_member(days=None):
+    tenant = Tenant(name=f"Test{uuid.uuid4()}", identifier=str(uuid.uuid4())).save()
+    DayType.init_day_types(tenant)
+    vac = DayType.objects(tenant=tenant, identifier="vacation").first()
+    member_days = days or {}
+    member = TeamMember(
+        name="Alice",
+        country="Sweden",
+        employee_start_date=datetime.date(2024, 7, 1),
+        yearly_vacation_days=20,
+        days=member_days,
+    )
+    return member, vac, tenant
+
+
+def test_available_days_without_usage():
+    member, _, tenant = setup_member()
+    token = tenant_var.set(tenant)
+    member_dto = mongo_to_pydantic(member, TeamMemberReadDTO)
+    with patch("backend.main.get_today", return_value=datetime.date(2025, 1, 1)):
+        assert member_dto.vacation_available_days == 30
+    tenant_var.reset(token)
+
+
+def test_available_days_with_usage_and_plans():
+    used_and_planned = {}
+    member, vac, tenant = setup_member(used_and_planned)
+    # 5 used days in 2024
+    for i in range(1, 6):
+        member.days[f"2024-08-{i:02d}"] = DayEntry(day_types=[vac])
+    # 5 planned days in 2025
+    for i in range(1, 6):
+        member.days[f"2025-02-{i:02d}"] = DayEntry(day_types=[vac])
+
+    token = tenant_var.set(tenant)
+    member_dto = mongo_to_pydantic(member, TeamMemberReadDTO)
+    with patch("backend.main.get_today", return_value=datetime.date(2025, 1, 1)):
+        # 30 total budget - 5 used - 5 planned = 20
+        assert member_dto.vacation_available_days == 20
+    tenant_var.reset(token)

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,11 @@
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import App from './App';
+import {AuthContext} from './contexts/AuthContext';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+test('app renders without crashing', () => {
+  render(
+    <AuthContext.Provider value={{isAuthenticated: false}}>
+      <App />
+    </AuthContext.Provider>
+  );
 });

--- a/frontend/src/components/CalendarComponent.jsx
+++ b/frontend/src/components/CalendarComponent.jsx
@@ -404,6 +404,7 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
     const usedDays = member.vacation_used_days_by_year?.[selectedYear] || 0;
     const plannedDays = member.vacation_planned_days_by_year?.[selectedYear] || 0;
     const yearlyVacationDays = member.yearly_vacation_days;
+    const availableVacationDays = member.vacation_available_days;
     const usedText = usedDays
       ? `${usedDays} vacation days used in ${selectedYear}`
       : `No vacation days used in ${selectedYear}`;
@@ -413,6 +414,9 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
     const yearlyVacationDaysText = yearlyVacationDays
       ? `${yearlyVacationDays} vacation days available per year`
       : 'No yearly vacation days defined';
+    const availableVacationDaysText = (availableVacationDays || availableVacationDays === 0)
+      ? `${availableVacationDays} vacation days available`
+      : 'Vacation days availability unknown';
     let lines = [];
     if (selectedYear < currentYear) {
       lines.push(usedText);
@@ -421,7 +425,7 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
     } else {
       lines.push(usedText, plannedText);
     }
-    lines.push(yearlyVacationDaysText);
+    lines.push(yearlyVacationDaysText, availableVacationDaysText);
     return lines.join('\n');
   };
 
@@ -559,6 +563,7 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
         }}
         dayTypes={dayTypes}
         selectedDayInfo={selectedDayInfo}
+        teamData={teamData}
         updateTeamData={updateTeamData}
         updateLocalTeamData={updateLocalTeamData}
       />

--- a/frontend/src/components/DayTypeCheckbox.jsx
+++ b/frontend/src/components/DayTypeCheckbox.jsx
@@ -9,7 +9,7 @@ const DayTypeCheckbox = ({ type, selected, onChange = '' }) => {
         type="checkbox"
         id={`dayType-${type._id}`}
         value={type._id}
-        onChange={(e) => onChange(type._id, e.target.checked)}
+        onChange={(e) => onChange(type, e.target.checked)}
         checked={selected}
       />
       <label htmlFor={`dayType-${type._id}`}>


### PR DESCRIPTION
## Summary
- compute `vacation_available_days` for team members
- show available vacation days in the calendar tooltip
- block adding vacation days beyond available amount
- adjust DayType checkbox handler
- add backend tests for new logic
- warn when vacation limit exceeded
- prompt user before exceeding vacation days

## Testing
- `pip install -r backend/requirements.txt`
- `pip install httpx`
- `pytest backend`
- `npm install`
- `CI=true npm test --silent` *(fails: Cannot destructure property 'isMultitenancyEnabled' of '(0 , _ConfigContext.useConfig)(...)')*

------
https://chatgpt.com/codex/tasks/task_e_6870d3255c9883208a80db8e44e24c2f