### PR TITLE
Implement WebAuthn security keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@
 * See https://core.telegram.org/widgets/login
 * Configure TELEGRAM_BOT_TOKEN and TELEGRAM_BOT_USERNAME in the backend .env
 * Tip for local testing: https://stackoverflow.com/questions/61964889/testing-telegram-login-widget-locally
+#### WebAuthn security keys
+* Optionally register a hardware security key or biometric authenticator.
+* Enables passwordless login via the WebAuthn API.
 
 ### Calendar integration
 Teams expose a read-only iCalendar feed. A token is generated automatically

--- a/backend/main.py
+++ b/backend/main.py
@@ -19,7 +19,7 @@ from pydantic.functional_validators import field_validator, model_validator
 
 from .dependencies import create_access_token, get_current_active_user_check_tenant, get_tenant, TenantMiddleware
 from .model import User, Tenant
-from .routers import users, daytypes, management, teams
+from .routers import users, daytypes, management, teams, webauthn
 from .routers.teams import (
     TeamMemberWriteDTO,
     DayEntryDTO,
@@ -70,6 +70,7 @@ app.add_middleware(TenantMiddleware)
 app.include_router(users.router)
 app.include_router(daytypes.router)
 app.include_router(teams.router)
+app.include_router(webauthn.router)
 if MULTITENANCY_ENABLED:
     app.include_router(management.router)
 Instrumentator().instrument(app).expose(app)

--- a/backend/model.py
+++ b/backend/model.py
@@ -10,7 +10,7 @@ from dateutil.relativedelta import relativedelta
 from dotenv import load_dotenv
 from mongoengine import StringField, ListField, connect, Document, EmbeddedDocument, \
     EmbeddedDocumentListField, UUIDField, EmailField, ReferenceField, MapField, EmbeddedDocumentField, BooleanField, \
-    LongField, DateTimeField, IntField, DateField, DecimalField
+    LongField, DateTimeField, IntField, DateField, DecimalField, BinaryField
 import mongomock
 from passlib.context import CryptContext
 from pymongo import MongoClient
@@ -253,6 +253,20 @@ class PasswordResetToken(Document):
     def mark_as_used(self):
         self.status = "used"
         self.save()
+
+
+class WebAuthnCredential(Document):
+    """Stores registered WebAuthn credentials."""
+
+    user = ReferenceField(User, required=True, reverse_delete_rule=mongoengine.CASCADE)
+    credential_id = StringField(required=True, unique=True)
+    credential_data = BinaryField(required=True)
+    sign_count = IntField(default=0)
+
+    meta = {
+        "indexes": ["user", "credential_id"],
+        "index_background": True,
+    }
 
 
 def generate_random_hex_color():

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,3 +16,5 @@ pyjwt
 python-dateutil
 mongomock
 ics
+
+fido2

--- a/backend/routers/webauthn.py
+++ b/backend/routers/webauthn.py
@@ -1,0 +1,99 @@
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel
+from dataclasses import asdict
+from fido2.server import Fido2Server
+from fido2.webauthn import PublicKeyCredentialRpEntity, PublicKeyCredentialUserEntity, PublicKeyCredentialDescriptor, AttestedCredentialData
+from fido2.utils import websafe_encode, websafe_decode
+from ..model import User, WebAuthnCredential
+from ..dependencies import create_access_token
+
+router = APIRouter(prefix="/webauthn", tags=["WebAuthn"])
+
+rp = PublicKeyCredentialRpEntity(name="Vacal", id="vacal")
+server = Fido2Server(rp)
+
+registration_state = {}
+authentication_state = {}
+
+class UsernameModel(BaseModel):
+    username: str
+
+class CredentialModel(BaseModel):
+    id: str
+    rawId: str
+    response: dict
+    type: str
+
+class RegisterCompleteModel(BaseModel):
+    username: str
+    credential: CredentialModel
+
+class AuthenticateCompleteModel(BaseModel):
+    username: str
+    credential: CredentialModel
+
+@router.post("/register-options")
+def register_options(data: UsernameModel):
+    user = User.get_by_username(data.username)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    user_entity = PublicKeyCredentialUserEntity(id=data.username.encode(), name=data.username, display_name=user.name)
+    creds = [PublicKeyCredentialDescriptor(id=websafe_decode(c.credential_id), type="public-key")
+             for c in WebAuthnCredential.objects(user=user)]
+    opts, state = server.register_begin(user_entity, creds)
+    registration_state[data.username] = state
+    options = asdict(opts.public_key)
+    options["challenge"] = websafe_encode(options["challenge"])
+    options["user"]["id"] = websafe_encode(options["user"]["id"])
+    for cred in options.get("exclude_credentials", []):
+        cred["id"] = websafe_encode(cred["id"])
+    return options
+
+@router.post("/register")
+def register_complete(data: RegisterCompleteModel):
+    user = User.get_by_username(data.username)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    state = registration_state.pop(data.username, None)
+    if not state:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Registration not initiated")
+    credential = server.register_complete(state, data.credential.dict())
+    cred_data = credential.credential_data
+    WebAuthnCredential(
+        user=user,
+        credential_id=websafe_encode(cred_data.credential_id).decode(),
+        credential_data=bytes(cred_data),
+        sign_count=credential.counter
+    ).save()
+    return {"status": "ok"}
+
+@router.post("/authenticate-options")
+def authenticate_options(data: UsernameModel):
+    user = User.get_by_username(data.username)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    creds = [AttestedCredentialData(c.credential_data) for c in WebAuthnCredential.objects(user=user)]
+    if not creds:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No credentials")
+    opts, state = server.authenticate_begin(creds)
+    authentication_state[data.username] = (state, creds, user)
+    options = asdict(opts.public_key)
+    options["challenge"] = websafe_encode(options["challenge"])
+    for cred in options.get("allow_credentials", []):
+        cred["id"] = websafe_encode(cred["id"])
+    return options
+
+@router.post("/authenticate")
+def authenticate_complete(data: AuthenticateCompleteModel):
+    entry = authentication_state.pop(data.username, None)
+    if not entry:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Authentication not initiated")
+    state, creds, user = entry
+    credential = server.authenticate_complete(state, creds, data.credential.dict())
+    # update sign count
+    db_cred = WebAuthnCredential.objects(user=user, credential_id=websafe_encode(credential.credential_id).decode()).first()
+    if db_cred:
+        db_cred.sign_count = credential.counter
+        db_cred.save()
+    token = create_access_token(data={"sub": user.auth_details.username})
+    return {"access_token": token, "token_type": "bearer"}

--- a/frontend/src/components/auth/Login.jsx
+++ b/frontend/src/components/auth/Login.jsx
@@ -6,7 +6,7 @@ import TelegramLogin from "./TelegramLogin";
 import {useConfig} from "../../contexts/ConfigContext";
 
 const Login = () => {
-  const {handleLogin} = useAuth();
+  const {handleLogin, handleWebAuthnLogin} = useAuth();
   const navigate = useNavigate();
   const {isMultitenancyEnabled, isTelegramEnabled, telegramBotUsername, userInitiated} = useConfig();
   const [username, setUsername] = useState('');
@@ -53,13 +53,14 @@ const Login = () => {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             placeholder="Password"
-            className="inputStyle"
-          />
-          <button type="submit" className="buttonStyle">Log in</button>
-          <p
-            className="forgotPasswordLink"
-            onClick={() => navigate('/password-reset-request')}
-          >
+          className="inputStyle"
+        />
+        <button type="submit" className="buttonStyle">Log in</button>
+        <button type="button" className="buttonStyle" onClick={() => handleWebAuthnLogin(username)}>Use Security Key</button>
+        <p
+          className="forgotPasswordLink"
+          onClick={() => navigate('/password-reset-request')}
+        >
             Forgot password?
           </p>
         </form>

--- a/frontend/src/components/settings/SecurityKeyModal.jsx
+++ b/frontend/src/components/settings/SecurityKeyModal.jsx
@@ -1,0 +1,56 @@
+import React, {useRef} from 'react';
+import {useApi} from '../../hooks/useApi';
+import {useAuth} from '../../contexts/AuthContext';
+import {toast} from 'react-toastify';
+
+const bufferToBase64 = (buffer) => btoa(String.fromCharCode(...new Uint8Array(buffer)));
+const base64ToBuffer = (base64) => Uint8Array.from(atob(base64), c => c.charCodeAt(0));
+
+const SecurityKeyModal = ({isOpen, onClose}) => {
+    const modalContentRef = useRef(null);
+    const {apiCall} = useApi();
+    const {user} = useAuth();
+
+    const handleRegister = async () => {
+        try {
+            const opts = await apiCall('/webauthn/register-options', 'POST', {username: user.username});
+            opts.challenge = base64ToBuffer(opts.challenge);
+            opts.user.id = base64ToBuffer(opts.user.id);
+            if (opts.excludeCredentials) {
+                opts.excludeCredentials = opts.excludeCredentials.map(e => ({...e, id: base64ToBuffer(e.id)}));
+            }
+            const cred = await navigator.credentials.create({publicKey: opts});
+            const credential = {
+                id: bufferToBase64(cred.rawId),
+                rawId: bufferToBase64(cred.rawId),
+                type: cred.type,
+                response: {
+                    clientDataJSON: bufferToBase64(cred.response.clientDataJSON),
+                    attestationObject: bufferToBase64(cred.response.attestationObject)
+                }
+            };
+            await apiCall('/webauthn/register', 'POST', {username: user.username, credential});
+            toast('Security key registered');
+            onClose();
+        } catch (e) {
+            console.error(e);
+            toast.error('Registration failed');
+        }
+    };
+
+    if (!isOpen) return null;
+
+    return (
+        <div className="modal">
+            <div className="modal-content" ref={modalContentRef}>
+                <p>Register a security key for passwordless login.</p>
+                <div className="button-container">
+                    <button onClick={handleRegister}>Register</button>
+                    <button onClick={onClose}>Close</button>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default SecurityKeyModal;

--- a/frontend/src/components/settings/UserManagement.jsx
+++ b/frontend/src/components/settings/UserManagement.jsx
@@ -2,9 +2,10 @@ import React, {useEffect, useState} from 'react';
 import {useApi} from '../../hooks/useApi';
 import UserModal from './UserModal';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
-import {faEdit, faKey, faTrashAlt} from '@fortawesome/free-solid-svg-icons';
+import {faEdit, faKey, faTrashAlt, faFingerprint} from '@fortawesome/free-solid-svg-icons';
 import {useAuth} from "../../contexts/AuthContext";
 import PasswordChangeModal from "./PasswordChangeModal";
+import SecurityKeyModal from "./SecurityKeyModal";
 import InviteUserModal from './InviteUserModal';
 import InviteManagement from './InviteManagement';
 import {useLocation, useNavigate} from "react-router-dom";
@@ -18,6 +19,7 @@ const UserManagement = () => {
   const [showUserModal, setShowUserModal] = useState(false);
   const [showInviteModal, setShowInviteModal] = useState(false);
   const [showPasswordModal, setShowPasswordModal] = useState(false);
+  const [showKeyModal, setShowKeyModal] = useState(false);
   const [editingUser, setEditingUser] = useState(null);
   const [refreshInvites, setRefreshInvites] = useState(false);
 
@@ -127,6 +129,11 @@ const UserManagement = () => {
                                  className="actionIcon"
                 />
               )}
+              {u._id === user._id && (
+                <FontAwesomeIcon icon={faFingerprint}
+                                 onClick={() => setShowKeyModal(true)}
+                                 className="actionIcon"/>
+              )}
             </td>
           </tr>
         ))}
@@ -149,6 +156,12 @@ const UserManagement = () => {
         <PasswordChangeModal
           isOpen={showPasswordModal}
           onClose={() => setShowPasswordModal(false)}
+        />
+      )}
+      {showKeyModal && (
+        <SecurityKeyModal
+          isOpen={showKeyModal}
+          onClose={() => setShowKeyModal(false)}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- add `fido2` to backend requirements
- store credentials in new `WebAuthnCredential` model
- expose `/webauthn` routes for security key registration and authentication
- update login page and settings to support WebAuthn
- document WebAuthn option in README

## Testing
- `pytest backend`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68794af2cc908320a5d7a7c4d3981bf6