### PR TITLE
Add calendar name

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,4 @@ for each new team. Regenerate it via `POST /teams/{team_id}/calendar-token`
 and subscribe to `/calendar/{calendar_token}` in external calendars like
 Google Calendar. The feed returns all stored absences, so no dates need to
 be provided in the subscription URL.
+The calendar feed includes a `X-WR-CALNAME` property set to "<Team Name> - <Tenant Name> - Vacal" so subscribed calendars display a descriptive title.

--- a/backend/routers/teams.py
+++ b/backend/routers/teams.py
@@ -16,6 +16,7 @@ from bson import ObjectId
 from fastapi import APIRouter, status, Body, Depends, Query, HTTPException
 from fastapi.responses import RedirectResponse, StreamingResponse, Response
 from ics import Calendar, Event
+from ics.grammar.parse import ContentLine
 from openpyxl import Workbook
 from openpyxl.utils import get_column_letter
 from pycountry.db import Country
@@ -481,6 +482,11 @@ async def export_vacation_report(current_user: Annotated[User, Depends(get_curre
 
 def build_team_calendar(team: Team) -> Calendar:
     cal = Calendar()
+    # Add calendar name so external clients display a meaningful title
+    cal.extra.append(ContentLine(
+        "X-WR-CALNAME",
+        value=f"{team.name} - {team.tenant.name} - Vacal",
+    ))
     for member in sorted(team.team_members, key=lambda m: m.name):
         for date_str in sorted(member.days.keys()):
             day_entry = member.days[date_str]


### PR DESCRIPTION
## Summary
- name calendars in iCal feed using the team and tenant names
- document calendar naming in README

## Testing
- `pytest backend`

------
https://chatgpt.com/codex/tasks/task_e_687a7b641de08320abdb29242b74a4c1