### PR TITLE
Display team member count in UI

### DIFF
--- a/frontend/src/components/CalendarComponent.css
+++ b/frontend/src/components/CalendarComponent.css
@@ -117,6 +117,12 @@
     margin-right: 10px; /* Adjust as needed */
 }
 
+.team-member-count {
+    margin-left: 4px;
+    color: #555;
+    font-weight: normal;
+}
+
 .team-row {
     background-color: #f2f2f2;
     font-weight: bold;

--- a/frontend/src/components/CalendarComponent.jsx
+++ b/frontend/src/components/CalendarComponent.jsx
@@ -656,6 +656,7 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
                           <FontAwesomeIcon icon={faEye}/>
                       </span>
                       {team.name}
+                      <span className="team-member-count">({team.team_members.length})</span>
                       <span className="add-icon" onClick={() => handleAddMemberIconClick(team._id)}
                             title="Add team member">➕</span>
                       <span className="edit-icon" onClick={() => handleEditTeamClick(team._id)}>


### PR DESCRIPTION
## Summary
- show number of members for each team in the calendar interface
- style the member count in the table

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687f3efbcc5c8320bf4d01d0c394867d