### PR TITLE
Add watch toggle in calendar view

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 * Manage teams and team members effectively.
 * Organize and track vacation days.
 * Visualize vacation days, weekends, and public holidays in an intuitive interface.
+* Watch or unwatch teams directly from the calendar view for quick notifications.
 * Ideal for both local and distributed teams, enhancing team coordination and planning.
 
 ## Technologies

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 * Manage teams and team members effectively.
 * Organize and track vacation days.
 * Visualize vacation days, weekends, and public holidays in an intuitive interface.
-* Watch or unwatch teams directly from the calendar view for quick notifications.
 * Ideal for both local and distributed teams, enhancing team coordination and planning.
 
 ## Technologies

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,5 +1,5 @@
 # Use an official Node runtime as a parent image
-FROM node:20
+FROM node:24
 
 # Set the working directory in the container
 WORKDIR /usr/src/app

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.7.2",
+        "@fortawesome/free-regular-svg-icons": "^6.7.2",
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@mui/icons-material": "^7.2.0",
@@ -2541,6 +2542,18 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
       "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
       "license": "MIT",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.7.2.tgz",
+      "integrity": "sha512-7Z/ur0gvCMW8G93dXIQOkQqHo2M5HLhYrRVC0//fakJXxcF1VmMPsxnG6Ee8qEylA8b8Q3peQXWMNZ62lYF28g==",
+      "license": "(CC-BY-4.0 AND MIT)",
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.7.2"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.7.2",
+    "@fortawesome/free-regular-svg-icons": "^6.7.2",
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@mui/icons-material": "^7.2.0",

--- a/frontend/src/components/CalendarComponent.css
+++ b/frontend/src/components/CalendarComponent.css
@@ -136,6 +136,7 @@
 .team-name-cell .edit-icon,
 .team-name-cell .delete-icon,
 .team-name-cell .calendar-link-icon,
+.team-name-cell .watch-icon,
 .member-name-cell .drag-icon,
 .member-name-cell .edit-icon,
 .member-name-cell .delete-icon,
@@ -147,6 +148,7 @@
 .team-name-cell:hover .edit-icon,
 .team-name-cell:hover .delete-icon,
 .team-name-cell:hover .calendar-link-icon,
+.team-name-cell:hover .watch-icon,
 .member-name-cell:hover .drag-icon,
 .member-name-cell:hover .edit-icon,
 .member-name-cell:hover .delete-icon,
@@ -168,6 +170,16 @@
     cursor: pointer;
     margin-left: 10px;
     color: #0000ff;
+}
+
+.watch-icon {
+    cursor: pointer;
+    margin-left: 10px;
+}
+
+.watch-icon-active {
+    visibility: visible !important;
+    color: green;
 }
 
 .calendar-link-icon {

--- a/frontend/src/components/CalendarComponent.jsx
+++ b/frontend/src/components/CalendarComponent.jsx
@@ -2,6 +2,7 @@ import {eachDayOfInterval, endOfWeek, format, getISOWeek, isToday, isWeekend, is
 import React, {useEffect, useRef, useState} from 'react';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {
+  faBell as faSolidBell,
   faChevronDown,
   faChevronRight,
   faEdit,
@@ -10,10 +11,9 @@ import {
   faInfoCircle,
   faLink,
   faSave,
-  faTrashAlt,
-  faBell as faSolidBell
+  faTrashAlt
 } from '@fortawesome/free-solid-svg-icons';
-import { faBell as faRegularBell } from '@fortawesome/free-regular-svg-icons';
+import {faBell as faRegularBell} from '@fortawesome/free-regular-svg-icons';
 import {toast} from 'react-toastify';
 import './CalendarComponent.css';
 import MonthSelector from './MonthSelector';
@@ -562,8 +562,8 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
         onClose={() => {
           setShowAddTeamForm(false);
           setEditingTeam(null);
+          updateTeamData();
         }}
-        updateTeamData={updateTeamData}
         editingTeam={editingTeam}
       />
 

--- a/frontend/src/components/CalendarComponent.jsx
+++ b/frontend/src/components/CalendarComponent.jsx
@@ -10,7 +10,9 @@ import {
   faInfoCircle,
   faLink,
   faSave,
-  faTrashAlt
+  faTrashAlt,
+  faBell,
+  faBellOn
 } from '@fortawesome/free-solid-svg-icons';
 import {toast} from 'react-toastify';
 import './CalendarComponent.css';
@@ -19,9 +21,12 @@ import TeamModal from './TeamModal';
 import MemberModal from './MemberModal';
 import DayTypeContextMenu from './DayTypeContextMenu';
 import {useApi} from '../hooks/useApi';
+import {useAuth} from '../contexts/AuthContext';
+import {useTeamSubscription} from '../hooks/useTeamSubscription';
 
 const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData}) => {
   const {apiCall} = useApi();
+  const {user} = useAuth();
   const today = new Date();
   const todayMonth = today.getMonth(); // Note: getMonth() returns 0 for January, 1 for February, etc.
   const todayYear = today.getFullYear();
@@ -404,6 +409,20 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
     });
   };
 
+  const {toggleTeamSubscription} = useTeamSubscription();
+
+  const toggleWatchTeam = async (teamId) => {
+    const team = teamData.find(t => t._id === teamId);
+    if (!team) return;
+    const isSubscribed = team.subscribers?.some(sub => sub._id === user._id);
+    try {
+      await toggleTeamSubscription(teamId, isSubscribed);
+      updateTeamData();
+    } catch (error) {
+      console.error('Failed to toggle watch status:', error);
+    }
+  };
+
   const renderVacationDaysTooltip = (member) => {
     const selectedYear = displayMonth.getFullYear();
     const currentYear = new Date().getFullYear();
@@ -635,7 +654,9 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
           </tr>
           </thead>
           <tbody>
-          {filterTeamsAndMembers(teamData).map(team => (
+          {filterTeamsAndMembers(teamData).map(team => {
+            const isSubscribed = team.subscribers?.some(sub => sub._id === user._id);
+            return (
             <React.Fragment key={team.id}>
               {(!focusedTeamId || focusedTeamId === team._id) && (
                 <>
@@ -659,6 +680,11 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
                       <span className="team-member-count">({team.team_members.length})</span>
                       <span className="add-icon" onClick={() => handleAddMemberIconClick(team._id)}
                             title="Add team member">➕</span>
+                      <span className={`watch-icon ${isSubscribed ? 'watch-icon-active' : ''}`}
+                            onClick={() => toggleWatchTeam(team._id)}
+                            title={isSubscribed ? 'Unwatch team' : 'Watch team'}>
+                          <FontAwesomeIcon icon={isSubscribed ? faBellOn : faBell}/>
+                      </span>
                       <span className="edit-icon" onClick={() => handleEditTeamClick(team._id)}>
                           <FontAwesomeIcon icon={faEdit}/>
                       </span>
@@ -737,7 +763,8 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
                 </>
               )}
             </React.Fragment>
-          ))}
+            );
+          })}
           </tbody>
         </table>
       </div>

--- a/frontend/src/components/CalendarComponent.jsx
+++ b/frontend/src/components/CalendarComponent.jsx
@@ -11,9 +11,9 @@ import {
   faLink,
   faSave,
   faTrashAlt,
-  faBell,
-  faBellOn
+  faBell as faSolidBell
 } from '@fortawesome/free-solid-svg-icons';
+import { faBell as faRegularBell } from '@fortawesome/free-regular-svg-icons';
 import {toast} from 'react-toastify';
 import './CalendarComponent.css';
 import MonthSelector from './MonthSelector';
@@ -683,7 +683,7 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
                       <span className={`watch-icon ${isSubscribed ? 'watch-icon-active' : ''}`}
                             onClick={() => toggleWatchTeam(team._id)}
                             title={isSubscribed ? 'Unwatch team' : 'Watch team'}>
-                          <FontAwesomeIcon icon={isSubscribed ? faBellOn : faBell}/>
+                          <FontAwesomeIcon icon={isSubscribed ? faSolidBell : faRegularBell}/>
                       </span>
                       <span className="edit-icon" onClick={() => handleEditTeamClick(team._id)}>
                           <FontAwesomeIcon icon={faEdit}/>

--- a/frontend/src/components/TeamModal.jsx
+++ b/frontend/src/components/TeamModal.jsx
@@ -57,6 +57,7 @@ const TeamModal = ({isOpen, onClose, updateTeamData, editingTeam}) => {
     try {
       await toggleTeamSubscription(editingTeam._id, isSubscribed);
       await fetchSubscribers(); // Reload subscribers after (un)subscribing
+      updateTeamData(); // Refresh data on calendar list
     } catch (error) {
       console.error(`Error ${isSubscribed ? 'unsubscribing' : 'subscribing'} current user:`, error);
     }

--- a/frontend/src/components/TeamModal.jsx
+++ b/frontend/src/components/TeamModal.jsx
@@ -1,8 +1,9 @@
 import React, {useEffect, useRef, useState} from 'react';
-import {useApi} from '../hooks/useApi';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
-import {faUserPlus, faUserTimes} from '@fortawesome/free-solid-svg-icons';
+import {faBell, faBellOn} from '@fortawesome/free-solid-svg-icons';
 import {useAuth} from "../contexts/AuthContext";
+import {useTeamSubscription} from '../hooks/useTeamSubscription';
+import {useApi} from '../hooks/useApi';
 
 const TeamModal = ({isOpen, onClose, updateTeamData, editingTeam}) => {
   const [teamName, setTeamName] = useState('');
@@ -45,16 +46,15 @@ const TeamModal = ({isOpen, onClose, updateTeamData, editingTeam}) => {
     }
   };
 
+  const {toggleTeamSubscription} = useTeamSubscription();
+
   const handleSubscribeCurrentUser = async () => {
     if (!editingTeam) return;
 
-    try {
-      const isSubscribed = subscribers.some(subscriber => subscriber._id === user._id);
-      const endpoint = isSubscribed
-        ? `/teams/${editingTeam._id}/unsubscribe`
-        : `/teams/${editingTeam._id}/subscribe`;
+    const isSubscribed = subscribers.some(subscriber => subscriber._id === user._id);
 
-      await apiCall(endpoint, 'POST');
+    try {
+      await toggleTeamSubscription(editingTeam._id, isSubscribed);
       await fetchSubscribers(); // Reload subscribers after (un)subscribing
     } catch (error) {
       console.error(`Error ${isSubscribed ? 'unsubscribing' : 'subscribing'} current user:`, error);
@@ -108,7 +108,7 @@ const TeamModal = ({isOpen, onClose, updateTeamData, editingTeam}) => {
               className="subscribe-button"
               onClick={handleSubscribeCurrentUser}
             >
-              <FontAwesomeIcon icon={isSubscribed ? faUserTimes : faUserPlus} style={{marginRight: '5px'}}/>
+              <FontAwesomeIcon icon={isSubscribed ? faBellOn : faBell} style={{marginRight: '5px'}}/>
               {isSubscribed ? 'Unwatch' : 'Watch'}
             </button>
             {subscribers.map(subscriber => (

--- a/frontend/src/components/TeamModal.jsx
+++ b/frontend/src/components/TeamModal.jsx
@@ -6,7 +6,7 @@ import {useAuth} from "../contexts/AuthContext";
 import {useTeamSubscription} from '../hooks/useTeamSubscription';
 import {useApi} from '../hooks/useApi';
 
-const TeamModal = ({isOpen, onClose, updateTeamData, editingTeam}) => {
+const TeamModal = ({isOpen, onClose, editingTeam}) => {
   const [teamName, setTeamName] = useState('');
   const [subscribers, setSubscribers] = useState([]);
   const modalContentRef = useRef(null);
@@ -57,7 +57,6 @@ const TeamModal = ({isOpen, onClose, updateTeamData, editingTeam}) => {
     try {
       await toggleTeamSubscription(editingTeam._id, isSubscribed);
       await fetchSubscribers(); // Reload subscribers after (un)subscribing
-      updateTeamData(); // Refresh data on calendar list
     } catch (error) {
       console.error(`Error ${isSubscribed ? 'unsubscribing' : 'subscribing'} current user:`, error);
     }
@@ -76,7 +75,6 @@ const TeamModal = ({isOpen, onClose, updateTeamData, editingTeam}) => {
       await apiCall(url, method, payload);
       setTeamName('');
       onClose();
-      updateTeamData(); // Refresh data
     } catch (error) {
       console.error('Error in team operation:', error);
     }

--- a/frontend/src/components/TeamModal.jsx
+++ b/frontend/src/components/TeamModal.jsx
@@ -1,6 +1,7 @@
 import React, {useEffect, useRef, useState} from 'react';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
-import {faBell, faBellOn} from '@fortawesome/free-solid-svg-icons';
+import {faBell as faSolidBell} from '@fortawesome/free-solid-svg-icons';
+import {faBell as faRegularBell} from '@fortawesome/free-regular-svg-icons';
 import {useAuth} from "../contexts/AuthContext";
 import {useTeamSubscription} from '../hooks/useTeamSubscription';
 import {useApi} from '../hooks/useApi';
@@ -108,7 +109,7 @@ const TeamModal = ({isOpen, onClose, updateTeamData, editingTeam}) => {
               className="subscribe-button"
               onClick={handleSubscribeCurrentUser}
             >
-              <FontAwesomeIcon icon={isSubscribed ? faBellOn : faBell} style={{marginRight: '5px'}}/>
+              <FontAwesomeIcon icon={isSubscribed ? faSolidBell : faRegularBell} style={{marginRight: '5px'}}/>
               {isSubscribed ? 'Unwatch' : 'Watch'}
             </button>
             {subscribers.map(subscriber => (

--- a/frontend/src/hooks/useTeamSubscription.js
+++ b/frontend/src/hooks/useTeamSubscription.js
@@ -1,0 +1,14 @@
+import {useApi} from './useApi';
+
+export const useTeamSubscription = () => {
+  const {apiCall} = useApi();
+
+  const toggleTeamSubscription = async (teamId, isSubscribed) => {
+    const endpoint = isSubscribed
+      ? `/teams/${teamId}/unsubscribe`
+      : `/teams/${teamId}/subscribe`;
+    await apiCall(endpoint, 'POST');
+  };
+
+  return {toggleTeamSubscription};
+};


### PR DESCRIPTION
## Summary
- allow users to watch/unwatch teams from calendar view
- show active watch icon permanently and hide inactive one with other icons
- style watch icon and update documentation
- extract team watch functionality to shared hook to follow DRY principle
- change watch icons to `fa-bell-on` and `fa-bell`

## Testing
- `npm install`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6880e056b91c8320b21721b5cb1d3a42