### PR TITLE
Allow team selection for vacation export

### DIFF
--- a/backend/test_export.py
+++ b/backend/test_export.py
@@ -1,0 +1,42 @@
+import os
+os.environ.setdefault("MONGO_MOCK", "1")
+os.environ.setdefault("AUTHENTICATION_SECRET_KEY", "test_secret")
+
+from fastapi.testclient import TestClient
+from openpyxl import load_workbook
+from .main import app
+from .model import Tenant, DayType, Team, TeamMember, DayEntry, User
+import uuid
+
+client = TestClient(app)
+
+
+def setup_teams():
+    tenant = Tenant(name=f"Tenant{uuid.uuid4()}", identifier=str(uuid.uuid4())).save()
+    DayType.init_day_types(tenant)
+    vacation = DayType.objects(tenant=tenant, identifier="vacation").first()
+    member1 = TeamMember(name="Alice", country="Sweden", days={"2025-01-01": DayEntry(day_types=[vacation])})
+    team1 = Team(tenant=tenant, name="Team1", team_members=[member1])
+    team1.save()
+    member2 = TeamMember(name="Bob", country="Sweden", days={"2025-01-01": DayEntry(day_types=[vacation])})
+    team2 = Team(tenant=tenant, name="Team2", team_members=[member2])
+    team2.save()
+    return team1, team2
+
+
+from backend.dependencies import get_current_active_user_check_tenant, get_tenant
+
+
+def test_export_selected_team():
+    team1, team2 = setup_teams()
+    app.dependency_overrides[get_current_active_user_check_tenant] = lambda: User(tenants=[team1.tenant])
+    app.dependency_overrides[get_tenant] = lambda: team1.tenant
+    resp = client.get(f"/teams/export-vacations?start_date=2025-01-01&end_date=2025-12-31&team_ids={team1.id}")
+    assert resp.status_code == 200
+    app.dependency_overrides = {}
+    from io import BytesIO
+    wb = load_workbook(BytesIO(resp.content))
+    ws = wb.active
+    rows = list(ws.iter_rows(values_only=True))
+    assert any(r[0] == "Team1" for r in rows[1:])
+    assert not any(r[0] == "Team2" for r in rows[1:])

--- a/frontend/src/components/MainComponent.jsx
+++ b/frontend/src/components/MainComponent.jsx
@@ -69,9 +69,10 @@ const MainComponent = () => {
         setShowReportModal(true);
     };
 
-    const handleGenerateReport = async (startDate, endDate) => {
+    const handleGenerateReport = async (startDate, endDate, teamIds) => {
         setShowReportModal(false);
-        const reportUrl = `/teams/export-vacations?start_date=${startDate}&end_date=${endDate}`;
+        const teamsQuery = teamIds && teamIds.length > 0 ? `&${teamIds.map(id => `team_ids=${id}`).join('&')}` : '';
+        const reportUrl = `/teams/export-vacations?start_date=${startDate}&end_date=${endDate}${teamsQuery}`;
 
         try {
             const blob = await apiCall(reportUrl, 'GET', null, true); // Set isBlob to true
@@ -132,6 +133,7 @@ const MainComponent = () => {
                 isOpen={showReportModal}
                 onClose={() => setShowReportModal(false)}
                 onGenerateReport={handleGenerateReport}
+                teams={data.teams}
             />
         </div>
     );

--- a/frontend/src/components/ReportFormModal.jsx
+++ b/frontend/src/components/ReportFormModal.jsx
@@ -1,8 +1,9 @@
 import React, {useEffect, useRef, useState} from 'react';
 
-const ReportFormModal = ({ isOpen, onClose, onGenerateReport }) => {
+const ReportFormModal = ({ isOpen, onClose, onGenerateReport, teams = [] }) => {
     const [startDate, setStartDate] = useState('');
     const [endDate, setEndDate] = useState('');
+    const [selectedTeams, setSelectedTeams] = useState([]);
     const modalContentRef = useRef(null);
 
     useEffect(() => {
@@ -27,9 +28,24 @@ const ReportFormModal = ({ isOpen, onClose, onGenerateReport }) => {
         };
     }, [onClose]);
 
+    useEffect(() => {
+        if (isOpen) {
+            setSelectedTeams(teams.map(t => t._id));
+        }
+    }, [isOpen, teams]);
+
+    const handleTeamChange = (e) => {
+        const id = e.target.value;
+        if (e.target.checked) {
+            setSelectedTeams(prev => [...prev, id]);
+        } else {
+            setSelectedTeams(prev => prev.filter(tid => tid !== id));
+        }
+    };
+
     const handleSubmit = (e) => {
         e.preventDefault();
-        onGenerateReport(startDate, endDate);
+        onGenerateReport(startDate, endDate, selectedTeams);
         setStartDate(''); // Reset the start date state
         setEndDate('');   // Reset the end date state
         onClose();        // Close the modal
@@ -59,6 +75,20 @@ const ReportFormModal = ({ isOpen, onClose, onGenerateReport }) => {
                             required
                         />
                     </label>
+                    <fieldset>
+                        <legend>Select Teams</legend>
+                        {teams.map(team => (
+                            <label key={team._id} style={{display: 'block'}}>
+                                <input
+                                    type="checkbox"
+                                    value={team._id}
+                                    checked={selectedTeams.includes(team._id)}
+                                    onChange={handleTeamChange}
+                                />
+                                {team.name}
+                            </label>
+                        ))}
+                    </fieldset>
                     <div className="button-container">
                         <button type="submit">Generate Report</button>
                         <button type="button" onClick={onClose}>Close</button>


### PR DESCRIPTION
## Summary
- let `/teams/export-vacations` filter by team IDs
- add multi-select team field in report form modal
- generate query string for selected teams in main component
- test XLS export filtering by team

## Testing
- `pip install -r backend/requirements.txt`
- `pip install httpx`
- `pytest backend`
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6880d514085c83209ceb8698c1f59ece