### PR TITLE
Refactor localStorage usage in frontend

### DIFF
--- a/frontend/src/components/CalendarComponent.jsx
+++ b/frontend/src/components/CalendarComponent.jsx
@@ -23,6 +23,7 @@ import DayTypeContextMenu from './DayTypeContextMenu';
 import {useApi} from '../hooks/useApi';
 import {useAuth} from '../contexts/AuthContext';
 import {useTeamSubscription} from '../hooks/useTeamSubscription';
+import {useLocalStorage} from '../hooks/useLocalStorage';
 
 const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData}) => {
   const {apiCall} = useApi();
@@ -39,12 +40,9 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
   const [showAddTeamForm, setShowAddTeamForm] = useState(false);
   const stickyHeaderHeight = 44;
   const [selectedTeamId, setSelectedTeamId] = useState(null);
-  const savedCollapsedTeams = JSON.parse(localStorage.getItem('collapsedTeams')) || [];
-  const [collapsedTeams, setCollapsedTeams] = useState(savedCollapsedTeams);
-  const savedFocusedTeamId = localStorage.getItem('focusedTeamId');
-  const [focusedTeamId, setFocusedTeamId] = useState(savedFocusedTeamId);
-  const savedFilter = localStorage.getItem('vacalFilter') || '';
-  const [filterInput, setFilterInput] = useState(savedFilter);
+  const [collapsedTeams, setCollapsedTeams] = useLocalStorage('collapsedTeams', []);
+  const [focusedTeamId, setFocusedTeamId] = useLocalStorage('focusedTeamId', null);
+  const [filterInput, setFilterInput] = useLocalStorage('vacalFilter', '');
   const filterInputRef = useRef(null);
   const [editingTeam, setEditingTeam] = useState(null);
   const [editingMember, setEditingMember] = useState(null);
@@ -143,16 +141,9 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
   };
 
 
-  const saveToLocalStorage = (key, value) => {
-    localStorage.setItem(key, value);
+  const triggerSaveIcon = () => {
     setShowSaveIcon(true);
-    setTimeout(() => setShowSaveIcon(false), 1500); // Hide icon after 1.5 seconds
-  };
-
-  const removeFromLocalStorage = (key) => {
-    localStorage.removeItem(key);
-    setShowSaveIcon(true);
-    setTimeout(() => setShowSaveIcon(false), 1500); // Hide icon after 1.5 seconds
+    setTimeout(() => setShowSaveIcon(false), 1500);
   };
 
   useEffect(() => {
@@ -166,20 +157,8 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
   }, []);
 
   useEffect(() => {
-    saveToLocalStorage('collapsedTeams', JSON.stringify(collapsedTeams));
-  }, [collapsedTeams]);
-
-  useEffect(() => {
-    if (focusedTeamId) {
-      saveToLocalStorage('focusedTeamId', focusedTeamId);
-    } else {
-      removeFromLocalStorage('focusedTeamId');
-    }
-  }, [focusedTeamId]);
-
-  useEffect(() => {
-    saveToLocalStorage('vacalFilter', filterInput);
-  }, [filterInput]);
+    triggerSaveIcon();
+  }, [collapsedTeams, focusedTeamId, filterInput]);
 
   useEffect(() => {
     if (showAddMemberForm && addMemberFormRef.current) {

--- a/frontend/src/components/ReportFormModal.jsx
+++ b/frontend/src/components/ReportFormModal.jsx
@@ -1,9 +1,10 @@
 import React, {useEffect, useRef, useState} from 'react';
+import {useLocalStorage} from '../hooks/useLocalStorage';
 
 const ReportFormModal = ({ isOpen, onClose, onGenerateReport, teams = [] }) => {
     const [startDate, setStartDate] = useState('');
     const [endDate, setEndDate] = useState('');
-    const [selectedTeams, setSelectedTeams] = useState([]);
+    const [selectedTeams, setSelectedTeams] = useLocalStorage('reportSelectedTeams', []);
     const modalContentRef = useRef(null);
 
     useEffect(() => {
@@ -30,21 +31,14 @@ const ReportFormModal = ({ isOpen, onClose, onGenerateReport, teams = [] }) => {
 
     useEffect(() => {
         if (isOpen) {
-            const savedTeams = JSON.parse(localStorage.getItem('reportSelectedTeams') || '[]');
-            if (savedTeams.length > 0) {
-                const validTeams = teams.filter(t => savedTeams.includes(t._id)).map(t => t._id);
+            if (selectedTeams.length > 0) {
+                const validTeams = teams.filter(t => selectedTeams.includes(t._id)).map(t => t._id);
                 setSelectedTeams(validTeams);
             } else {
                 setSelectedTeams(teams.map(t => t._id));
             }
         }
     }, [isOpen, teams]);
-
-    useEffect(() => {
-        if (isOpen) {
-            localStorage.setItem('reportSelectedTeams', JSON.stringify(selectedTeams));
-        }
-    }, [selectedTeams, isOpen]);
 
     const handleTeamChange = (e) => {
         const id = e.target.value;

--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -1,24 +1,20 @@
 import React, {createContext, useContext, useEffect, useState} from 'react';
 import {toast} from 'react-toastify';
+import {useLocalStorage} from '../hooks/useLocalStorage';
 
 export const AuthContext = createContext();
 
 export const AuthProvider = ({children}) => {
-    const [isAuthenticated, setIsAuthenticated] = useState(localStorage.getItem("isAuthenticated") === "true");
-    const [authHeader, setAuthHeader] = useState(localStorage.getItem("authHeader") || '');
-    const [currentTenant, setCurrentTenant] = useState(localStorage.getItem("currentTenant") || '');
+    const [isAuthenticated, setIsAuthenticated] = useLocalStorage('isAuthenticated', false);
+    const [authHeader, setAuthHeader] = useLocalStorage('authHeader', '');
+    const [currentTenant, setCurrentTenant] = useLocalStorage('currentTenant', '');
     const [user, setUser] = useState(null);
 
     useEffect(() => {
-        localStorage.setItem("isAuthenticated", isAuthenticated);
-        localStorage.setItem("authHeader", authHeader);
-        if (currentTenant) {
-            localStorage.setItem("currentTenant", currentTenant);
-        }
         if (authHeader) {
             fetchCurrentUser();
         }
-    }, [isAuthenticated, authHeader, currentTenant]);
+    }, [authHeader, currentTenant]);
 
     const fetchCurrentUser = async (token) => {
         const response = await fetch(`${process.env.REACT_APP_API_URL}/users/me`, {

--- a/frontend/src/hooks/useLocalStorage.js
+++ b/frontend/src/hooks/useLocalStorage.js
@@ -1,0 +1,24 @@
+import {useEffect, useState} from 'react';
+
+export const useLocalStorage = (key, defaultValue) => {
+  const [value, setValue] = useState(() => {
+    const stored = localStorage.getItem(key);
+    if (stored === null) return defaultValue;
+    try {
+      return JSON.parse(stored);
+    } catch {
+      return stored;
+    }
+  });
+
+  useEffect(() => {
+    if (value === undefined || value === null) {
+      localStorage.removeItem(key);
+    } else {
+      const toStore = typeof value === 'string' ? value : JSON.stringify(value);
+      localStorage.setItem(key, toStore);
+    }
+  }, [key, value]);
+
+  return [value, setValue];
+};


### PR DESCRIPTION
## Summary
- add a reusable `useLocalStorage` hook
- use the new hook in `AuthContext`, `ReportFormModal` and `CalendarComponent`
- remove direct `localStorage` calls and unify save indicator

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_688136294e008320a6a4987fadea853a