### PR TITLE
Show counts in user settings tables

### DIFF
--- a/frontend/src/components/settings/InviteManagement.jsx
+++ b/frontend/src/components/settings/InviteManagement.jsx
@@ -38,7 +38,7 @@ const InviteManagement = ({ refreshTrigger }) => {
 
     return (
       <div className="inviteManagementContainer">
-          <h3>Pending invites</h3>
+          <h3>Pending invites ({invites.length})</h3>
           <table className="settingsTable">
               <thead>
               <tr>

--- a/frontend/src/components/settings/UserManagement.jsx
+++ b/frontend/src/components/settings/UserManagement.jsx
@@ -90,7 +90,7 @@ const UserManagement = () => {
     <div className="settingsUserManagementContainer">
       <h2>User Management Settings</h2>
       <InviteManagement refreshTrigger={refreshInvites}/>
-      <h3>Users</h3>
+      <h3>Users ({users.length})</h3>
       <div className="userManagementButtons">
         <button onClick={handleInviteUserClick}>Invite User</button>
       </div>


### PR DESCRIPTION
## Summary
- display number of pending invites in InviteManagement header
- display number of existing users in UserManagement

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_688243212b488320a78cb7ae3bd516e2