### PR TITLE
Fix invite duplicate email warning

### DIFF
--- a/frontend/src/components/settings/InviteUserModal.jsx
+++ b/frontend/src/components/settings/InviteUserModal.jsx
@@ -30,7 +30,13 @@ const InviteUserModal = ({ isOpen, onClose }) => {
             toast.success('Invitation sent successfully');
         } catch (error) {
             console.error('Error sending invitation:', error);
-            toast.error('Failed to send invitation: ' + error?.data?.detail);
+            const detail = error?.data?.detail;
+            if (detail === 'User already invited' ||
+                detail === 'User with this email already exists in the Workspace') {
+                toast.warn(detail);
+            } else {
+                toast.error('Failed to send invitation: ' + detail);
+            }
         }
     };
 


### PR DESCRIPTION
## Summary
- show toast warning instead of error when inviting a user that already exists

## Testing
- `npm install --prefix frontend`
- `CI=true npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68823f48e9548320a3d16105b8c94d18