### PR TITLE
Allow selecting range with existing day types

### DIFF
--- a/frontend/src/components/CalendarComponent.jsx
+++ b/frontend/src/components/CalendarComponent.jsx
@@ -60,12 +60,8 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
   const [selectedCells, setSelectedCells] = useState([]);
   const [selectionDayTypes, setSelectionDayTypes] = useState([]);
 
-  const arraysEqual = (a = [], b = []) => {
-    if (a.length !== b.length) return false;
-    const sortedA = [...a].sort();
-    const sortedB = [...b].sort();
-    return sortedA.every((val, idx) => val === sortedB[idx]);
-  };
+  const isSubset = (subset = [], superset = []) =>
+    subset.every((val) => superset.includes(val));
 
   const isSelectableDay = (member, date, baseTypes = []) => {
     const dateStr = formatDate(date);
@@ -73,7 +69,7 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
     const dayTypeIds = (dayEntry?.day_types || []).map(dt => dt._id);
 
     if (baseTypes.length > 0) {
-      return arraysEqual(dayTypeIds, baseTypes);
+      return isSubset(baseTypes, dayTypeIds);
     }
 
     const hasExistingDayTypes = dayTypeIds.length > 0;

--- a/frontend/src/components/DayTypeContextMenu.jsx
+++ b/frontend/src/components/DayTypeContextMenu.jsx
@@ -21,6 +21,11 @@ const DayTypeContextMenu = ({
   const [initialComment, setInitialComment] = useState('');
   const {apiCall} = useApi();
 
+  const visibleDayTypes =
+    selectedDayInfo.dateRange.length > 1 && selectedDayInfo.existingDayTypes.length > 0
+      ? selectedDayInfo.existingDayTypes
+      : dayTypes;
+
   useEffect(() => {
     if (isOpen) {
       const dayTypeIds = selectedDayInfo.existingDayTypes.map((type) => type._id);
@@ -134,7 +139,7 @@ const DayTypeContextMenu = ({
         &times;
       </div>
 
-      {dayTypes.map((type) => {
+      {visibleDayTypes.map((type) => {
         if (type.identifier === 'vacation') {
           return (
             <DayTypeCheckbox
@@ -163,7 +168,7 @@ const DayTypeContextMenu = ({
         onBlur={handleCommentBlur}
       />
 
-      {dayTypes
+      {visibleDayTypes
         .filter((type) => type.identifier !== 'vacation' && type.identifier !== 'birthday')
         .map((type) => {
           // If it's an override type and the condition is not met, return null immediately.

--- a/frontend/src/components/DayTypeContextMenu.jsx
+++ b/frontend/src/components/DayTypeContextMenu.jsx
@@ -22,7 +22,10 @@ const DayTypeContextMenu = ({
   const {apiCall} = useApi();
 
   const visibleDayTypes =
-    selectedDayInfo.dateRange.length > 1 && selectedDayInfo.existingDayTypes.length > 0
+    isOpen &&
+    selectedDayInfo &&
+    selectedDayInfo.dateRange?.length > 1 &&
+    selectedDayInfo.existingDayTypes?.length > 0
       ? selectedDayInfo.existingDayTypes
       : dayTypes;
 


### PR DESCRIPTION
## Summary
- permit selecting contiguous days that already share the same day types
- pre-select those day types in the context menu and only show them when editing an existing range

## Testing
- `npm test --silent --prefix .`

------
https://chatgpt.com/codex/tasks/task_e_6881f392ab5c8320b104d4f032dddf12