### PR TITLE
Scope calendar preferences per tenant

### DIFF
--- a/frontend/src/components/CalendarComponent.jsx
+++ b/frontend/src/components/CalendarComponent.jsx
@@ -23,7 +23,7 @@ import DayTypeContextMenu from './DayTypeContextMenu';
 import {useApi} from '../hooks/useApi';
 import {useAuth} from '../contexts/AuthContext';
 import {useTeamSubscription} from '../hooks/useTeamSubscription';
-import {useLocalStorage} from '../hooks/useLocalStorage';
+import {useTenantLocalStorage} from '../hooks/useTenantLocalStorage';
 
 const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData}) => {
   const {apiCall} = useApi();
@@ -40,9 +40,9 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
   const [showAddTeamForm, setShowAddTeamForm] = useState(false);
   const stickyHeaderHeight = 44;
   const [selectedTeamId, setSelectedTeamId] = useState(null);
-  const [collapsedTeams, setCollapsedTeams] = useLocalStorage('collapsedTeams', []);
-  const [focusedTeamId, setFocusedTeamId] = useLocalStorage('focusedTeamId', null);
-  const [filterInput, setFilterInput] = useLocalStorage('vacalFilter', '');
+  const [collapsedTeams, setCollapsedTeams] = useTenantLocalStorage('collapsedTeams', []);
+  const [focusedTeamId, setFocusedTeamId] = useTenantLocalStorage('focusedTeamId', null);
+  const [filterInput, setFilterInput] = useTenantLocalStorage('vacalFilter', '');
   const filterInputRef = useRef(null);
   const [editingTeam, setEditingTeam] = useState(null);
   const [editingMember, setEditingMember] = useState(null);

--- a/frontend/src/components/ReportFormModal.jsx
+++ b/frontend/src/components/ReportFormModal.jsx
@@ -1,10 +1,10 @@
 import React, {useEffect, useRef, useState} from 'react';
-import {useLocalStorage} from '../hooks/useLocalStorage';
+import {useTenantLocalStorage} from '../hooks/useTenantLocalStorage';
 
 const ReportFormModal = ({ isOpen, onClose, onGenerateReport, teams = [] }) => {
     const [startDate, setStartDate] = useState('');
     const [endDate, setEndDate] = useState('');
-    const [selectedTeams, setSelectedTeams] = useLocalStorage('reportSelectedTeams', []);
+    const [selectedTeams, setSelectedTeams] = useTenantLocalStorage('reportSelectedTeams', []);
     const modalContentRef = useRef(null);
 
     useEffect(() => {

--- a/frontend/src/hooks/useTenantLocalStorage.js
+++ b/frontend/src/hooks/useTenantLocalStorage.js
@@ -1,25 +1,37 @@
-import { useEffect } from 'react';
-import { useAuth } from '../contexts/AuthContext';
-import { useLocalStorage } from './useLocalStorage';
+import {useEffect, useState} from 'react';
+import {useAuth} from '../contexts/AuthContext';
 
 export const useTenantLocalStorage = (key, defaultValue) => {
-  const { currentTenant } = useAuth();
+  const {currentTenant} = useAuth();
   const tenantKey = currentTenant ? `${currentTenant}_${key}` : key;
-  const [value, setValue] = useLocalStorage(tenantKey, defaultValue);
 
-  useEffect(() => {
+  const readValue = () => {
     const stored = localStorage.getItem(tenantKey);
-    if (stored === null) {
-      setValue(defaultValue);
-    } else {
-      try {
-        setValue(JSON.parse(stored));
-      } catch {
-        setValue(stored);
-      }
+    if (stored === null) return defaultValue;
+    try {
+      return JSON.parse(stored);
+    } catch {
+      return stored;
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  };
+
+  const [value, setValue] = useState(readValue);
+
+  // Update value when tenant changes
+  useEffect(() => {
+    setValue(readValue());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tenantKey]);
+
+  // Persist value whenever it changes
+  useEffect(() => {
+    if (value === undefined || value === null) {
+      localStorage.removeItem(tenantKey);
+    } else {
+      const toStore = typeof value === 'string' ? value : JSON.stringify(value);
+      localStorage.setItem(tenantKey, toStore);
+    }
+  }, [tenantKey, value]);
 
   return [value, setValue];
 };

--- a/frontend/src/hooks/useTenantLocalStorage.js
+++ b/frontend/src/hooks/useTenantLocalStorage.js
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+import { useLocalStorage } from './useLocalStorage';
+
+export const useTenantLocalStorage = (key, defaultValue) => {
+  const { currentTenant } = useAuth();
+  const tenantKey = currentTenant ? `${currentTenant}_${key}` : key;
+  const [value, setValue] = useLocalStorage(tenantKey, defaultValue);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(tenantKey);
+    if (stored === null) {
+      setValue(defaultValue);
+    } else {
+      try {
+        setValue(JSON.parse(stored));
+      } catch {
+        setValue(stored);
+      }
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tenantKey]);
+
+  return [value, setValue];
+};

--- a/frontend/src/hooks/useTenantLocalStorage.js
+++ b/frontend/src/hooks/useTenantLocalStorage.js
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useEffect, useLayoutEffect, useState} from 'react';
 import {useAuth} from '../contexts/AuthContext';
 
 export const useTenantLocalStorage = (key, defaultValue) => {
@@ -17,11 +17,10 @@ export const useTenantLocalStorage = (key, defaultValue) => {
 
   const [value, setValue] = useState(readValue);
 
-  // Update value when tenant changes
-  useEffect(() => {
+  // Load the stored value as soon as the tenant changes
+  useLayoutEffect(() => {
     setValue(readValue());
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tenantKey]);
+  }, [currentTenant]);
 
   // Persist value whenever it changes
   useEffect(() => {


### PR DESCRIPTION
## Summary
- add `useTenantLocalStorage` hook
- scope stored calendar settings to the current tenant

## Testing
- `npm ci`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6882538bc9708320907acc0adf58431f