### PR TITLE
Fix user icon overlay when modal open

### DIFF
--- a/frontend/src/components/MainComponent.css
+++ b/frontend/src/components/MainComponent.css
@@ -19,7 +19,7 @@
     position: fixed;
     top: 10px;
     right: 20px;
-    z-index: 5000;
+    z-index: 1000;
     display: flex;
     gap: 20px; /* Adjust this value based on desired spacing between icons */
 }

--- a/frontend/src/components/UserProfileMenu.css
+++ b/frontend/src/components/UserProfileMenu.css
@@ -7,7 +7,7 @@
     border-radius: 5px;
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
     width: 200px; /* Adjust width as needed */
-    z-index: 5001; /* Above the userIcon */
+    z-index: 1001; /* Above the userIcon but below modals */
 }
 
 .dropdownItem {


### PR DESCRIPTION
## Summary
- keep user dropdown below the modal overlay
- make user icon container lower `z-index`

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68832c0f47148320aff18a9a0d9a99d6