### PR TITLE
Fix upcoming vacation notifications

### DIFF
--- a/backend/scheduled/vacation_starts.py
+++ b/backend/scheduled/vacation_starts.py
@@ -122,7 +122,7 @@ def send_upcoming_vacation_email_updates() -> None:
         # Identify the vacation DayType ID for the tenant
         vacation_day_type = DayType.objects(tenant=team.tenant, identifier="vacation").first()
         for member in team.team_members:
-            if not is_working_day(member, today) or is_vacation(member, today, vacation_day_type):
+            if not is_working_day(member, today) or is_vacation(member, str(today), vacation_day_type):
                 continue  # skip sending notifications on weekends, holidays and if it is already vacation for the team member
             next_working_day = get_next_working_day(member, today)
             vacations_next_day = find_vacation_periods(team, next_working_day)

--- a/backend/test_upcoming_vacation.py
+++ b/backend/test_upcoming_vacation.py
@@ -1,0 +1,49 @@
+import os
+os.environ.setdefault("MONGO_MOCK", "1")
+os.environ.setdefault("AUTHENTICATION_SECRET_KEY", "test_secret")
+
+import datetime
+import uuid
+from unittest.mock import patch
+
+from backend.model import Tenant, DayType, Team, TeamMember, DayEntry, User, AuthDetails
+from backend.scheduled.vacation_starts import send_upcoming_vacation_email_updates
+
+
+def setup_team_with_ongoing_vacation(today: datetime.date):
+    tenant = Tenant(name=f"Tenant{uuid.uuid4()}", identifier=str(uuid.uuid4())).save()
+    DayType.init_day_types(tenant)
+    vacation = DayType.objects(tenant=tenant, identifier="vacation").first()
+
+    # Subscriber to receive notifications
+    subscriber = User(
+        tenants=[tenant],
+        name="Subscriber",
+        email="sub@example.com",
+        auth_details=AuthDetails(username="sub")
+    ).save()
+
+    start = today - datetime.timedelta(days=1)  # vacation started yesterday
+    end = today + datetime.timedelta(days=3)
+    days = {}
+    current = start
+    while current <= end:
+        days[str(current)] = DayEntry(day_types=[vacation])
+        current += datetime.timedelta(days=1)
+
+    member = TeamMember(name="Alice", country="Sweden", email="alice@example.com", days=days)
+    Team(tenant=tenant, name="Team", team_members=[member], subscribers=[subscriber]).save()
+    return subscriber.email
+
+
+def test_upcoming_vacation_excludes_ongoing_vacation():
+    today = datetime.date(2025, 9, 5)
+    email = setup_team_with_ongoing_vacation(today)
+
+    with patch("backend.scheduled.vacation_starts.send_email") as mock_send_email, \
+         patch("backend.scheduled.vacation_starts.datetime") as mock_datetime:
+        mock_datetime.date.today.return_value = today
+        mock_datetime.timedelta = datetime.timedelta
+        send_upcoming_vacation_email_updates()
+        # No email should be sent because the vacation already started
+        mock_send_email.assert_not_called()


### PR DESCRIPTION
## Summary
- skip notifications for vacations already in progress
- add regression test for upcoming vacation emails

## Testing
- `pip install -r backend/requirements.txt`
- `pip install httpx`
- `pytest backend`

------
https://chatgpt.com/codex/tasks/task_e_688344804104832086df644e06a71600