### PR TITLE
Improve password reset security

### DIFF
--- a/backend/test_password_reset.py
+++ b/backend/test_password_reset.py
@@ -1,0 +1,42 @@
+import os
+os.environ.setdefault("MONGO_MOCK", "1")
+os.environ.setdefault("AUTHENTICATION_SECRET_KEY", "test_secret")
+
+import hashlib
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+
+from .main import app
+from .model import Tenant, User, AuthDetails, PasswordResetToken
+
+client = TestClient(app)
+
+
+def setup_user():
+    tenant = Tenant(name="TestTenant", identifier="testtenant").save()
+    user = User(tenants=[tenant], name="Test User", email="user@example.com",
+                auth_details=AuthDetails(username="user"))
+    user.hash_password("oldpassword")
+    user.save()
+    return user
+
+
+def test_password_reset_token_hashed_and_usable():
+    user = setup_user()
+    captured = {}
+
+    def fake_send_email(email, token):
+        captured["token"] = token
+
+    with patch("backend.routers.users.send_password_reset_email", fake_send_email):
+        resp = client.post("/users/password-reset/request", json={"email": "user@example.com"})
+        assert resp.status_code == 200
+
+    prt = PasswordResetToken.objects(user=user).first()
+    assert prt is not None
+    assert prt.token == hashlib.sha256(captured["token"].encode()).hexdigest()
+
+    resp = client.post(f"/users/password-reset/{captured['token']}", json={"new_password": "newpass", "confirm_password": "newpass"})
+    assert resp.status_code == 200
+    user.reload()
+    assert user.verify_password("newpass")


### PR DESCRIPTION
## Summary
- hash password reset tokens before storing in DB
- test that the hashed token works and that passwords can be reset

## Testing
- `pytest backend`

------
https://chatgpt.com/codex/tasks/task_e_688347677a308320bc9513769abf8220