### PR TITLE
Fix Telegram username case sensitivity

### DIFF
--- a/backend/model.py
+++ b/backend/model.py
@@ -190,7 +190,7 @@ class User(Document):
 
     @classmethod
     def get_by_telegram_username(cls, username):
-        user = cls.objects(auth_details__telegram_username=username).first()
+        user = cls.objects(auth_details__telegram_username__iexact=username).first()
         return user
 
     def remove_tenant(self, tenant):

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -222,7 +222,7 @@ async def update_user(user_id: str, user_update: UserUpdateModel,
     if not user_update.telegram_username:
         user.auth_details.telegram_username = None
     else:
-        user.auth_details.telegram_username = user_update.telegram_username
+        user.auth_details.telegram_username = user_update.telegram_username.lower()
     # Don't update password here; handle password updates separately for security
     user.save()
     UserWithoutTenantsDTO.from_mongo_reference_field.cache_clear()
@@ -463,7 +463,7 @@ async def register_user_via_invite(token: str, user_creation: UserCreationModel)
         user.email = invite.email
         user.auth_details = AuthDetails(
             username=user_creation.username,
-            telegram_username=user_creation.telegram_username if user_creation.telegram_username else None
+            telegram_username=(user_creation.telegram_username.lower() if user_creation.telegram_username else None)
         )
         user.hash_password(user_creation.password)
         user.save()

--- a/backend/test_telegram_login.py
+++ b/backend/test_telegram_login.py
@@ -1,0 +1,48 @@
+import os
+import time
+import hashlib
+import hmac
+
+os.environ.setdefault("MONGO_MOCK", "1")
+os.environ.setdefault("AUTHENTICATION_SECRET_KEY", "test_secret")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "testtoken")
+os.environ.setdefault("TELEGRAM_BOT_USERNAME", "testbot")
+
+from fastapi.testclient import TestClient
+from .main import app, TELEGRAM_BOT_TOKEN
+from .model import User, AuthDetails
+
+client = TestClient(app)
+
+
+def test_telegram_login_case_insensitive():
+    user = User(
+        name="TG User",
+        email="tg@example.com",
+        auth_details=AuthDetails(username="tguser", telegram_username="TelegramUser")
+    )
+    user.save()
+
+    auth_date = int(time.time())
+    username_login = "telegramuser"
+    data_check_arr = [
+        f"auth_date={auth_date}",
+        "id=1",
+        f"username={username_login}"
+    ]
+    data_check_arr.sort()
+    data_check_string = "\n".join(data_check_arr)
+    secret_key = hashlib.sha256(TELEGRAM_BOT_TOKEN.encode()).digest()
+    calculated_hash = hmac.new(secret_key, data_check_string.encode(), hashlib.sha256).hexdigest()
+
+    payload = {
+        "hash": calculated_hash,
+        "id": 1,
+        "auth_date": auth_date,
+        "username": username_login,
+    }
+
+    response = client.post("/telegram-login", json=payload)
+    assert response.status_code == 200
+    token = response.json().get("access_token")
+    assert token


### PR DESCRIPTION
## Summary
- normalize Telegram usernames when storing and searching
- handle updates and invites in lowercase
- add test ensuring Telegram login works regardless of case

## Testing
- `pip install -r backend/requirements.txt`
- `pip install httpx`
- `pytest backend`

------
https://chatgpt.com/codex/tasks/task_e_6883435050ec8320893c3e78dccb2b29