### PR TITLE
Switch to pwdlib for password hashing

### DIFF
--- a/backend/model.py
+++ b/backend/model.py
@@ -12,14 +12,18 @@ from dotenv import load_dotenv
 from mongoengine import StringField, ListField, connect, Document, EmbeddedDocument, \
     EmbeddedDocumentListField, UUIDField, EmailField, ReferenceField, MapField, EmbeddedDocumentField, BooleanField, \
     LongField, DateTimeField, IntField, DateField, DecimalField
-from passlib.context import CryptContext
+from pwdlib import PasswordHash
+from pwdlib.hashers.argon2 import Argon2Hasher
+from pwdlib.hashers.bcrypt import BcryptHasher
 from pymongo import MongoClient
 
 from .mongodb_migration_engine import run_migrations
 
 log = logging.getLogger(__name__)
 
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+# Configure password hashing to use Argon2 for new hashes while
+# still accepting existing bcrypt hashes for verification.
+pwd_context = PasswordHash((Argon2Hasher(), BcryptHasher()))
 
 # in production the environments should be set and not loaded from .env
 load_dotenv()  # mostly for local development with docker-compose

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,7 +11,7 @@ apscheduler
 openpyxl
 prometheus-fastapi-instrumentator
 python-multipart
-passlib[bcrypt]
+pwdlib[argon2,bcrypt]
 pyjwt
 python-dateutil
 mongomock

--- a/backend/test_password_hashing.py
+++ b/backend/test_password_hashing.py
@@ -1,0 +1,20 @@
+import os
+os.environ.setdefault("MONGO_MOCK", "1")
+os.environ.setdefault("AUTHENTICATION_SECRET_KEY", "test_secret")
+
+import uuid
+from backend.model import Tenant, User, AuthDetails
+from pwdlib.hashers.bcrypt import BcryptHasher
+
+
+def test_verify_legacy_bcrypt_password():
+    tenant = Tenant(name=str(uuid.uuid4()), identifier=str(uuid.uuid4())).save()
+    bcrypt_hash = BcryptHasher().hash("secret")
+    user = User(
+        tenants=[tenant],
+        name="User",
+        email="u@example.com",
+        auth_details=AuthDetails(username="user", hashed_password=bcrypt_hash),
+    )
+    assert user.verify_password("secret")
+


### PR DESCRIPTION
## Summary
- migrate backend password hashing from passlib to pwdlib using Argon2
- keep backward compatibility with legacy bcrypt hashes
- add regression test for legacy bcrypt hashes

## Testing
- `pip install -r backend/requirements.txt`
- `pip install httpx`
- `pytest backend`

------
https://chatgpt.com/codex/tasks/task_e_6884e699edcc832098c0a5f1c7983fc2