### PR TITLE
User API key instead of common calendar key

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@
 * Tip for local testing: https://stackoverflow.com/questions/61964889/testing-telegram-login-widget-locally
 
 ### Calendar integration
-Teams expose a read-only iCalendar feed. A token is generated automatically
-for each new team. Regenerate it via `POST /teams/{team_id}/calendar-token`
-and subscribe to `/calendar/{calendar_token}` in external calendars like
-Google Calendar. The feed returns all stored absences, so no dates need to
-be provided in the subscription URL.
+Teams expose a read-only iCalendar feed. Subscribe using
+`/calendar/{team_id}?user_api_key={user_api_key}` in external calendars like
+Google Calendar. The user API key is generated for each user and allows access
+to be revoked when the user is removed. The feed returns
+all stored absences, so no dates need to be provided in the subscription URL.

--- a/backend/db_migrations/m2025_07_30_001_generate_user_api_keys.py
+++ b/backend/db_migrations/m2025_07_30_001_generate_user_api_keys.py
@@ -1,0 +1,12 @@
+import secrets
+from .db_utils import db
+
+collection = db['user']
+for user in collection.find():
+    auth_details = user.get('auth_details', {})
+    if not auth_details.get('api_key'):
+        token = secrets.token_urlsafe(16)
+        collection.update_one({'_id': user['_id']}, {'$set': {'auth_details.api_key': token}})
+        print(f"Set api_key for user {user['_id']}")
+
+print("Migration completed successfully.")

--- a/backend/db_migrations/m2025_07_30_002_remove_calendar_tokens.py
+++ b/backend/db_migrations/m2025_07_30_002_remove_calendar_tokens.py
@@ -1,0 +1,5 @@
+from .db_utils import db
+
+team_collection = db['team']
+updated = team_collection.update_many({'calendar_token': {'$exists': True}}, {'$unset': {'calendar_token': ""}})
+print(f"Removed calendar_token from {updated.modified_count} teams")

--- a/backend/model.py
+++ b/backend/model.py
@@ -154,6 +154,8 @@ class AuthDetails(EmbeddedDocument):
     # Fields for username/password authentication
     username = StringField(unique=True, required=True, sparse=True)
     hashed_password = StringField(required=False)
+    # Unique token used for accessing calendar feeds
+    api_key = StringField(unique=True, default=lambda: secrets.token_urlsafe(16))
 
 
 class User(Document):
@@ -169,7 +171,8 @@ class User(Document):
             "auth_details.telegram_id",
             "auth_details.telegram_username",
             "auth_details.username",
-            "tenants"
+            "tenants",
+            "auth_details.api_key"
         ],
         "index_background": True
     }
@@ -327,10 +330,6 @@ class Team(Document):
     team_members = EmbeddedDocumentListField(TeamMember)
     available_day_types = ListField(ReferenceField(DayType))
     subscribers = ListField(ReferenceField(User, reverse_delete_rule=mongoengine.PULL))
-    # Unique token used for unauthenticated calendar feeds.
-    # `sparse=True` allows multiple documents with a null or empty value.
-    calendar_token = StringField(unique=True, sparse=True,
-                                 default=lambda: secrets.token_urlsafe(16))
 
     meta = {
         "indexes": [

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -40,6 +40,7 @@ class AuthDetailsDTO(BaseModel):
     telegram_id: int | None = None
     telegram_username: str | None = None
     username: str
+    api_key: str | None = None
 
 
 class UserWithoutTenantsDTO(BaseModel):

--- a/backend/test_calendar.py
+++ b/backend/test_calendar.py
@@ -3,28 +3,50 @@ os.environ.setdefault("MONGO_MOCK", "1")
 os.environ.setdefault("AUTHENTICATION_SECRET_KEY", "test_secret")
 
 from fastapi.testclient import TestClient
+import uuid
 from .main import app
-from .model import Tenant, DayType, Team, TeamMember, DayEntry
+from .model import Tenant, DayType, Team, TeamMember, DayEntry, User, AuthDetails
 
 client = TestClient(app)
 
 
 def setup_team():
-    tenant = Tenant(name="Test Tenant", identifier="test").save()
+    tenant = Tenant(name=f"Tenant{uuid.uuid4()}", identifier=str(uuid.uuid4())).save()
     DayType.init_day_types(tenant)
     vacation = DayType.objects(tenant=tenant, identifier="vacation").first()
     member = TeamMember(name="Alice", country="Sweden", days={"2025-01-01": DayEntry(day_types=[vacation])})
-    team = Team(tenant=tenant, name="Team", team_members=[member], calendar_token="tok123")
-    team.save()
-    return team
+    user = User(
+        tenants=[tenant],
+        name="Subscriber",
+        email=f"sub{uuid.uuid4()}@example.com",
+        auth_details=AuthDetails(username=str(uuid.uuid4()))
+    ).save()
+    team = Team(
+        tenant=tenant,
+        name="Team",
+        team_members=[member],
+        subscribers=[user],
+    ).save()
+    return team, user
 
 
 def test_calendar_feed_deterministic():
-    setup_team()
-    resp1 = client.get("/teams/calendar/tok123")
-    resp2 = client.get("/teams/calendar/tok123")
+    team, user = setup_team()
+    url = f"/teams/calendar/{team.id}?user_api_key={user.auth_details.api_key}"
+    resp1 = client.get(url)
+    resp2 = client.get(url)
     assert resp1.status_code == 200
     assert resp1.status_code == resp2.status_code
     assert resp1.text == resp2.text
     assert "BEGIN:VEVENT" in resp1.text
     assert "VALUE=DATE" in resp1.text
+
+
+def test_calendar_feed_revoked_after_user_deleted():
+    team, user = setup_team()
+    api_key = user.auth_details.api_key
+    # Remove user from the system entirely
+    user.delete()
+    url = f"/teams/calendar/{team.id}?user_api_key={api_key}"
+    resp = client.get(url)
+    assert resp.status_code == 404

--- a/backend/test_upcoming_vacation.py
+++ b/backend/test_upcoming_vacation.py
@@ -19,8 +19,8 @@ def setup_team_with_ongoing_vacation(today: datetime.date):
     subscriber = User(
         tenants=[tenant],
         name="Subscriber",
-        email="sub@example.com",
-        auth_details=AuthDetails(username="sub")
+        email=f"sub{uuid.uuid4()}@example.com",
+        auth_details=AuthDetails(username=str(uuid.uuid4()))
     ).save()
 
     start = today - datetime.timedelta(days=1)  # vacation started yesterday

--- a/frontend/src/components/CalendarComponent.jsx
+++ b/frontend/src/components/CalendarComponent.jsx
@@ -398,8 +398,8 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
     setFocusedTeamId(prev => (prev === teamId ? null : teamId));
   };
 
-  const handleCopyCalendarLink = (token) => {
-    const link = `${process.env.REACT_APP_API_URL}/teams/calendar/${token}`;
+  const handleCopyCalendarLink = (teamId) => {
+    const link = `${process.env.REACT_APP_API_URL}/teams/calendar/${teamId}?user_api_key=${user.auth_details.api_key}`;
     navigator.clipboard.writeText(link).then(() => {
       toast.success('Calendar link copied');
     }).catch(() => {
@@ -686,7 +686,7 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
                       <span className="edit-icon" onClick={() => handleEditTeamClick(team._id)}>
                           <FontAwesomeIcon icon={faEdit}/>
                       </span>
-                      <span className="calendar-link-icon" onClick={() => handleCopyCalendarLink(team.calendar_token)}
+                      <span className="calendar-link-icon" onClick={() => handleCopyCalendarLink(team._id)}
                             title="Copy calendar feed link">
                           <FontAwesomeIcon icon={faLink}/>
                       </span>


### PR DESCRIPTION
## Summary
- remove the access check that rejected users not subscribed to a team
- update calendar test to verify feed is blocked after the user is deleted
- expose `api_key` in user DTO
- update frontend calendar link to include the user API key

## Testing
- `pytest backend`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6885e02eb57483209b1e314e8be9d484