### PR TITLE
Frontend MFA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@
 * The backend uses TOTP-based MFA via `pyotp`.
 * Every user has an `mfa_secret` generated automatically and the `/token` endpoint enforces MFA.
 * On the first login, the server returns a QR code provisioning URI so you can scan it with your authenticator app and confirm the OTP.
-* The frontend login form displays a QR code and OTP field during this initial setup.
+* The login page first asks for your username and password. If MFA isn't configured yet,
+  you'll see a QR code to scan and an OTP field. Returning users are prompted for
+  their one-time code after submitting credentials.
 
 ### Calendar integration
 Teams expose a read-only iCalendar feed. Subscribe using

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@
 * See https://core.telegram.org/widgets/login
 * Configure TELEGRAM_BOT_TOKEN and TELEGRAM_BOT_USERNAME in the backend .env
 * Tip for local testing: https://stackoverflow.com/questions/61964889/testing-telegram-login-widget-locally
+#### Multi-factor authentication
+* The backend uses TOTP-based MFA via `pyotp`.
+* Every user has an `mfa_secret` generated automatically and the `/token` endpoint enforces MFA.
+* On the first login, the server returns a QR code provisioning URI so you can scan it with your authenticator app and confirm the OTP.
+* The frontend login form displays a QR code and OTP field during this initial setup.
 
 ### Calendar integration
 Teams expose a read-only iCalendar feed. Subscribe using

--- a/backend/db_migrations/m2025_07_31_001_generate_mfa_secrets.py
+++ b/backend/db_migrations/m2025_07_31_001_generate_mfa_secrets.py
@@ -1,0 +1,10 @@
+import pyotp
+from .db_utils import db
+
+collection = db['user']
+for user in collection.find({'auth_details.mfa_secret': {'$exists': False}}):
+    secret = pyotp.random_base32()
+    collection.update_one({'_id': user['_id']}, {'$set': {'auth_details.mfa_secret': secret}})
+    print(f"Set mfa_secret for user {user['_id']}")
+
+print("Migration completed successfully.")

--- a/backend/db_migrations/m2025_07_31_002_set_mfa_confirmed.py
+++ b/backend/db_migrations/m2025_07_31_002_set_mfa_confirmed.py
@@ -1,0 +1,8 @@
+from .db_utils import db
+
+collection = db['user']
+result = collection.update_many(
+    {'auth_details.mfa_confirmed': {'$exists': False}},
+    {'$set': {'auth_details.mfa_confirmed': False}}
+)
+print(f"Updated {result.modified_count} users with mfa_confirmed=False")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,3 +16,4 @@ pyjwt
 python-dateutil
 mongomock
 ics
+pyotp

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -28,17 +28,19 @@ def mock_user():
     return User(
         auth_details=AuthDetails(
             username="testuser",
-            hashed_password="hashed_password"  # This should be a properly hashed password in reality
+            hashed_password="hashed_password",  # This should be a properly hashed password in reality
+            mfa_confirmed=True
         )
     )
 
 
 def test_login_for_access_token(mock_user):
     # Mock the authenticate_user method
-    with patch.object(User, 'authenticate_user', return_value=mock_user):
+    with patch.object(User, 'authenticate_user', return_value=mock_user), \
+         patch.object(mock_user, 'verify_mfa_code', return_value=True):
         response = client.post(
             "/token",
-            data={"username": "testuser", "password": "testpassword"},
+            data={"username": "testuser", "password": "testpassword", "otp": "123456"},
             headers={"Content-Type": "application/x-www-form-urlencoded"}
         )
 
@@ -53,7 +55,7 @@ def test_login_for_access_token_invalid_credentials():
     with patch.object(User, 'authenticate_user', return_value=None):
         response = client.post(
             "/token",
-            data={"username": "wronguser", "password": "wrongpassword"},
+            data={"username": "wronguser", "password": "wrongpassword", "otp": "000000"},
             headers={"Content-Type": "application/x-www-form-urlencoded"}
         )
 

--- a/backend/test_mfa.py
+++ b/backend/test_mfa.py
@@ -1,0 +1,79 @@
+import os
+os.environ.setdefault("MONGO_MOCK", "1")
+os.environ.setdefault("AUTHENTICATION_SECRET_KEY", "test_secret")
+
+import pyotp
+from fastapi.testclient import TestClient
+
+from .main import app
+from .model import Tenant, User, AuthDetails
+import uuid
+
+client = TestClient(app)
+
+
+def create_mfa_user():
+    tenant = Tenant(name=str(uuid.uuid4()), identifier=str(uuid.uuid4())).save()
+    username = str(uuid.uuid4())
+    email = f"{username}@example.com"
+    user = User(tenants=[tenant], name="Admin", email=email,
+                auth_details=AuthDetails(username=username))
+    user.hash_password("pass")
+    user.save()
+    return user, user.auth_details.mfa_secret
+
+
+def test_mfa_setup_and_confirmation():
+    user, secret = create_mfa_user()
+    # First login without OTP should return setup information
+    resp = client.post(
+        "/token",
+        data={"username": user.auth_details.username, "password": "pass"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"}
+    )
+    assert resp.status_code == 403
+    data = resp.json()
+    assert "otp_uri" in data
+
+    totp = pyotp.TOTP(secret)
+    code = totp.now()
+    # Providing correct code confirms MFA and logs in
+    resp = client.post(
+        "/token",
+        data={"username": user.auth_details.username, "password": "pass", "otp": code},
+        headers={"Content-Type": "application/x-www-form-urlencoded"}
+    )
+    assert resp.status_code == 200
+    user.reload()
+    assert user.auth_details.mfa_confirmed is True
+
+
+def test_confirmed_user_requires_valid_mfa_code():
+    user, secret = create_mfa_user()
+    user.auth_details.mfa_confirmed = True
+    user.save()
+    totp = pyotp.TOTP(secret)
+    # Missing OTP should fail with 401
+    resp = client.post(
+        "/token",
+        data={"username": user.auth_details.username, "password": "pass"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"}
+    )
+    assert resp.status_code == 401
+
+    # Wrong OTP should fail
+    resp = client.post(
+        "/token",
+        data={"username": user.auth_details.username, "password": "pass", "otp": "000000"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"}
+    )
+    assert resp.status_code == 401
+
+    # Correct OTP succeeds
+    code = totp.now()
+    resp = client.post(
+        "/token",
+        data={"username": user.auth_details.username, "password": "pass", "otp": code},
+        headers={"Content-Type": "application/x-www-form-urlencoded"}
+    )
+    assert resp.status_code == 200

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "@testing-library/user-event": "^14.6.1",
         "date-fns": "^4.1.0",
         "moment": "^2.30.1",
+        "qrcode": "^1.5.1",
         "react": "^19.1.0",
         "react-big-calendar": "^1.19.4",
         "react-dom": "^19.1.0",
@@ -6915,6 +6916,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -7095,6 +7105,12 @@
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -12721,6 +12737,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -14201,6 +14226,98 @@
         "teleport": ">=0.2.0"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/qs": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
@@ -14876,6 +14993,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -15489,6 +15612,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -17729,6 +17858,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
     },
     "node_modules/which-typed-array": {
       "version": "1.1.19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "react-router-dom": "^6.30.1",
     "react-scripts": "^5.0.1",
     "react-toastify": "^11.0.5",
+    "qrcode": "^1.5.1",
     "web-vitals": "^5.0.3"
   },
   "scripts": {

--- a/frontend/src/components/auth/Login.css
+++ b/frontend/src/components/auth/Login.css
@@ -79,3 +79,14 @@ h3 {
 .forgotPasswordLink:hover {
     text-decoration: underline;
 }
+
+.qrImage {
+    margin-top: 10px;
+    width: 150px;
+    height: 150px;
+}
+
+.errorMessage {
+    color: red;
+    margin-top: 10px;
+}

--- a/frontend/src/components/auth/Login.css
+++ b/frontend/src/components/auth/Login.css
@@ -86,7 +86,7 @@ h3 {
     height: 150px;
 }
 
-.errorMessage {
-    color: red;
+.infoMessage {
+    color: black;
     margin-top: 10px;
 }

--- a/frontend/src/components/auth/Login.jsx
+++ b/frontend/src/components/auth/Login.jsx
@@ -28,20 +28,22 @@ const Login = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     const result = await handleLogin(username, password, otp);
-    if (result && result.otpUri) {
+    if (result?.otpUri) {
       const url = await QRCode.toDataURL(result.otpUri);
       setQrData(url);
       setStep('mfa-setup');
       setMessage('Scan this QR code with your authenticator app and enter the generated code.');
-    } else if (result && result.invalidOtp) {
+    } else if (result?.invalidOtp) {
       setStep('mfa');
       if (step === 'credentials') {
         setMessage('Please enter your one-time code.');
       } else {
         toast.error('Invalid one-time code.');
       }
-    } else if (!result || result.success) {
+    } else if (result?.success) {
       navigate('/');
+    } else if (result?.error) {
+      toast.error(result.error);
     } else {
       toast.error('Authentication failed');
     }

--- a/frontend/src/components/auth/Login.jsx
+++ b/frontend/src/components/auth/Login.jsx
@@ -1,4 +1,5 @@
 import React, {useEffect, useState} from 'react';
+import QRCode from 'qrcode';
 import './Login.css';
 import {useAuth} from "../../contexts/AuthContext";
 import {useNavigate} from "react-router-dom";
@@ -11,6 +12,8 @@ const Login = () => {
   const {isMultitenancyEnabled, isTelegramEnabled, telegramBotUsername, userInitiated} = useConfig();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
+  const [otp, setOtp] = useState('');
+  const [qrData, setQrData] = useState(null);
 
 
   useEffect(() => {
@@ -21,8 +24,13 @@ const Login = () => {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    await handleLogin(username, password);
-    navigate('/');
+    const result = await handleLogin(username, password, otp);
+    if (result && result.otpUri) {
+      const url = await QRCode.toDataURL(result.otpUri);
+      setQrData(url);
+    } else if (!result || result.success) {
+      navigate('/');
+    }
   };
 
   return (
@@ -55,6 +63,17 @@ const Login = () => {
             placeholder="Password"
             className="inputStyle"
           />
+          <input
+            type="text"
+            name="otp"
+            value={otp}
+            onChange={(e) => setOtp(e.target.value)}
+            placeholder="One-time code"
+            className="inputStyle"
+          />
+          {qrData && (
+            <img src={qrData} alt="Scan QR code to setup MFA" className="qrImage" />
+          )}
           <button type="submit" className="buttonStyle">Log in</button>
           <p
             className="forgotPasswordLink"

--- a/frontend/src/components/auth/Login.jsx
+++ b/frontend/src/components/auth/Login.jsx
@@ -14,6 +14,8 @@ const Login = () => {
   const [password, setPassword] = useState('');
   const [otp, setOtp] = useState('');
   const [qrData, setQrData] = useState(null);
+  const [step, setStep] = useState('credentials');
+  const [message, setMessage] = useState('');
 
 
   useEffect(() => {
@@ -28,8 +30,15 @@ const Login = () => {
     if (result && result.otpUri) {
       const url = await QRCode.toDataURL(result.otpUri);
       setQrData(url);
+      setStep('mfa-setup');
+      setMessage('Scan this QR code with your authenticator app and enter the generated code.');
+    } else if (result && result.invalidOtp) {
+      setStep('mfa');
+      setMessage('Invalid or missing one-time code.');
     } else if (!result || result.success) {
       navigate('/');
+    } else {
+      setMessage('Authentication failed');
     }
   };
 
@@ -63,17 +72,23 @@ const Login = () => {
             placeholder="Password"
             className="inputStyle"
           />
-          <input
-            type="text"
-            name="otp"
-            value={otp}
-            onChange={(e) => setOtp(e.target.value)}
-            placeholder="One-time code"
-            className="inputStyle"
-          />
-          {qrData && (
-            <img src={qrData} alt="Scan QR code to setup MFA" className="qrImage" />
+          {step !== 'credentials' && (
+            <>
+              <input
+                type="text"
+                name="otp"
+                value={otp}
+                onChange={(e) => setOtp(e.target.value)}
+                placeholder="One-time code"
+                className="inputStyle"
+                autoFocus={true}
+              />
+              {qrData && (
+                <img src={qrData} alt="Scan QR code to setup MFA" className="qrImage" />
+              )}
+            </>
           )}
+          {message && <div className="errorMessage">{message}</div>}
           <button type="submit" className="buttonStyle">Log in</button>
           <p
             className="forgotPasswordLink"

--- a/frontend/src/components/auth/Login.jsx
+++ b/frontend/src/components/auth/Login.jsx
@@ -3,6 +3,7 @@ import QRCode from 'qrcode';
 import './Login.css';
 import {useAuth} from "../../contexts/AuthContext";
 import {useNavigate} from "react-router-dom";
+import {toast} from 'react-toastify';
 import TelegramLogin from "./TelegramLogin";
 import {useConfig} from "../../contexts/ConfigContext";
 
@@ -37,12 +38,12 @@ const Login = () => {
       if (step === 'credentials') {
         setMessage('Please enter your one-time code.');
       } else {
-        setMessage('Invalid one-time code.');
+        toast.error('Invalid one-time code.');
       }
     } else if (!result || result.success) {
       navigate('/');
     } else {
-      setMessage('Authentication failed');
+      toast.error('Authentication failed');
     }
   };
 
@@ -92,7 +93,7 @@ const Login = () => {
               )}
             </>
           )}
-          {message && <div className="errorMessage">{message}</div>}
+          {message && <div className="infoMessage">{message}</div>}
           <button type="submit" className="buttonStyle">Log in</button>
           <p
             className="forgotPasswordLink"

--- a/frontend/src/components/auth/Login.jsx
+++ b/frontend/src/components/auth/Login.jsx
@@ -34,7 +34,11 @@ const Login = () => {
       setMessage('Scan this QR code with your authenticator app and enter the generated code.');
     } else if (result && result.invalidOtp) {
       setStep('mfa');
-      setMessage('Invalid or missing one-time code.');
+      if (step === 'credentials') {
+        setMessage('Please enter your one-time code.');
+      } else {
+        setMessage('Invalid one-time code.');
+      }
     } else if (!result || result.success) {
       navigate('/');
     } else {

--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -66,15 +66,13 @@ export const AuthProvider = ({children}) => {
             if (data.detail === 'Invalid MFA code') {
                 return {invalidOtp: true};
             }
-            toast.error('Authentication failed');
             setIsAuthenticated(false);
             setAuthHeader('');
-            return {success: false};
+            return {error: data.detail || 'Authentication failed'};
         } else {
-            toast.error('Authentication failed');
             setIsAuthenticated(false);
             setAuthHeader('');
-            return {success: false};
+            return {error: 'Authentication failed'};
         }
     };
 

--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -38,11 +38,17 @@ export const AuthProvider = ({children}) => {
     };
 
 
-    const handleLogin = async (username, password) => {
+    const handleLogin = async (username, password, otp) => {
+        let body =
+            `username=${encodeURIComponent(username)}` +
+            `&password=${encodeURIComponent(password)}`;
+        if (otp) {
+            body += `&otp=${encodeURIComponent(otp)}`;
+        }
         const response = await fetch(`${process.env.REACT_APP_API_URL}/token`, {
             method: 'POST',
             headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-            body: `username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`,
+            body,
         });
 
         if (response.ok) {
@@ -51,10 +57,15 @@ export const AuthProvider = ({children}) => {
             setAuthHeader(newAuthHeader);
             setIsAuthenticated(true);
             await fetchCurrentUser(newAuthHeader);
+            return {success: true};
+        } else if (response.status === 403) {
+            const data = await response.json();
+            return {otpUri: data.otp_uri};
         } else {
             toast('Authentication failed');
             setIsAuthenticated(false);
             setAuthHeader('');
+            return {success: false};
         }
     };
 

--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -66,12 +66,12 @@ export const AuthProvider = ({children}) => {
             if (data.detail === 'Invalid MFA code') {
                 return {invalidOtp: true};
             }
-            toast('Authentication failed');
+            toast.error('Authentication failed');
             setIsAuthenticated(false);
             setAuthHeader('');
             return {success: false};
         } else {
-            toast('Authentication failed');
+            toast.error('Authentication failed');
             setIsAuthenticated(false);
             setAuthHeader('');
             return {success: false};

--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -61,6 +61,15 @@ export const AuthProvider = ({children}) => {
         } else if (response.status === 403) {
             const data = await response.json();
             return {otpUri: data.otp_uri};
+        } else if (response.status === 401) {
+            const data = await response.json();
+            if (data.detail === 'Invalid MFA code') {
+                return {invalidOtp: true};
+            }
+            toast('Authentication failed');
+            setIsAuthenticated(false);
+            setAuthHeader('');
+            return {success: false};
         } else {
             toast('Authentication failed');
             setIsAuthenticated(false);


### PR DESCRIPTION
## Summary
- add OTP field to login form
- send OTP to backend during login
- document MFA requirement in README
- add OTP onboarding with QR code

## Testing
- `pytest backend -q`
- `npm test -- -w 0`

------
https://chatgpt.com/codex/tasks/task_e_68862f18ced083208a8aab472c7ff448