### PR TITLE
Implement MFA reset functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 * The login page first asks for your username and password. If MFA isn't configured yet,
   you'll see a QR code to scan and an OTP field. Returning users are prompted for
   their one-time code after submitting credentials.
+* MFA can be reset for a user via `POST /users/{user_id}/reset-mfa` which generates a new secret and marks MFA as unconfirmed.
 
 ### Calendar integration
 Teams expose a read-only iCalendar feed. Subscribe using

--- a/frontend/src/components/settings/UserManagement.jsx
+++ b/frontend/src/components/settings/UserManagement.jsx
@@ -2,8 +2,9 @@ import React, {useEffect, useState} from 'react';
 import {useApi} from '../../hooks/useApi';
 import UserModal from './UserModal';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
-import {faEdit, faKey, faTrashAlt} from '@fortawesome/free-solid-svg-icons';
+import {faEdit, faKey, faTrashAlt, faSyncAlt} from '@fortawesome/free-solid-svg-icons';
 import {useAuth} from "../../contexts/AuthContext";
+import {toast} from 'react-toastify';
 import PasswordChangeModal from "./PasswordChangeModal";
 import InviteUserModal from './InviteUserModal';
 import InviteManagement from './InviteManagement';
@@ -86,6 +87,24 @@ const UserManagement = () => {
     setShowPasswordModal(true);
   };
 
+  const handleResetMfa = async (userId, userName) => {
+    const isConfirmed = window.confirm(`Reset MFA for ${userName}?`);
+    if (isConfirmed) {
+      try {
+        const data = await apiCall(`/users/${userId}/reset-mfa`, 'POST');
+        toast.success(data.message);
+        fetchUsers();
+      } catch (error) {
+        console.error('Error resetting MFA:', error);
+        if (error.data && error.data.detail) {
+          toast.error(error.data.detail);
+        } else {
+          toast.error('Error resetting MFA');
+        }
+      }
+    }
+  };
+
   return (
     <div className="settingsUserManagementContainer">
       <h2>User Management Settings</h2>
@@ -120,6 +139,9 @@ const UserManagement = () => {
               />
               <FontAwesomeIcon icon={faTrashAlt}
                                onClick={() => handleDeleteUser(u._id, u.name)}
+                               className="actionIcon"/>
+              <FontAwesomeIcon icon={faSyncAlt}
+                               onClick={() => handleResetMfa(u._id, u.name)}
                                className="actionIcon"/>
               {u._id === user._id && (
                 <FontAwesomeIcon icon={faKey}


### PR DESCRIPTION
## Summary
- add `/users/{user_id}/reset-mfa` endpoint for admins to reset MFA
- document MFA reset API in README
- test MFA reset logic
- allow resetting MFA from the settings UI
- show success or error using toast messages

## Testing
- `pytest backend`
- `npm test --prefix frontend --silent`


------
https://chatgpt.com/codex/tasks/task_e_688799d733ec832099b891c589171d0b