### PR TITLE
Add alt titles for user action icons

### DIFF
--- a/frontend/src/components/settings/UserManagement.jsx
+++ b/frontend/src/components/settings/UserManagement.jsx
@@ -136,17 +136,25 @@ const UserManagement = () => {
               <FontAwesomeIcon icon={faEdit}
                                onClick={() => handleEditUserClick(u)}
                                className="firstActionIcon"
+                               title="Edit user"
+                               aria-label="Edit user"
               />
               <FontAwesomeIcon icon={faTrashAlt}
                                onClick={() => handleDeleteUser(u._id, u.name)}
-                               className="actionIcon"/>
+                               className="actionIcon"
+                               title="Delete user"
+                               aria-label="Delete user"/>
               <FontAwesomeIcon icon={faSyncAlt}
                                onClick={() => handleResetMfa(u._id, u.name)}
-                               className="actionIcon"/>
+                               className="actionIcon"
+                               title="Reset MFA"
+                               aria-label="Reset MFA"/>
               {u._id === user._id && (
                 <FontAwesomeIcon icon={faKey}
                                  onClick={() => handlePasswordChangeClick(u)}
                                  className="actionIcon"
+                                 title="Change password"
+                                 aria-label="Change password"
                 />
               )}
             </td>


### PR DESCRIPTION
## Summary
- improve accessibility by adding alt titles to action icons in user settings

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6887b0f819748320bfa06ede63e45289