### PR TITLE
Simplify context providers

### DIFF
--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -5,10 +5,10 @@ import {ConfigContext} from './contexts/ConfigContext';
 
 test('app renders without crashing', () => {
   render(
-    <AuthContext.Provider value={{isAuthenticated: false}}>
-      <ConfigContext.Provider value={{isMultitenancyEnabled: false, isTelegramEnabled: false, telegramBotUsername: '', userInitiated: true}}>
+    <AuthContext value={{isAuthenticated: false}}>
+      <ConfigContext value={{isMultitenancyEnabled: false, isTelegramEnabled: false, telegramBotUsername: '', userInitiated: true}}>
         <App />
-      </ConfigContext.Provider>
-    </AuthContext.Provider>
+      </ConfigContext>
+    </AuthContext>
   );
 });

--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -108,9 +108,9 @@ export const AuthProvider = ({children}) => {
     };
 
     return (
-        <AuthContext.Provider value={{isAuthenticated, authHeader, currentTenant, handleLogin, handleTelegramLogin, handleLogout, setCurrentTenant, user}}>
+        <AuthContext value={{isAuthenticated, authHeader, currentTenant, handleLogin, handleTelegramLogin, handleLogout, setCurrentTenant, user}}>
             {children}
-        </AuthContext.Provider>
+        </AuthContext>
     );
 };
 

--- a/frontend/src/contexts/ConfigContext.js
+++ b/frontend/src/contexts/ConfigContext.js
@@ -31,7 +31,7 @@ export const ConfigProvider = ({children}) => {
   }, []);
 
   return (
-    <ConfigContext.Provider
+    <ConfigContext
       value={{
         isMultitenancyEnabled,
         isTelegramEnabled,
@@ -41,7 +41,7 @@ export const ConfigProvider = ({children}) => {
       }}
     >
       {children}
-    </ConfigContext.Provider>
+    </ConfigContext>
   );
 };
 


### PR DESCRIPTION
## Summary
- streamline context provider components with React 19 syntax
- adjust tests accordingly

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6887b11a874c832086e5edd968bdb4cd