### PR TITLE
Add day audit history

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 * Manage teams and team members effectively.
 * Organize and track vacation days.
+* Keep a history of all day modifications.
 * Visualize vacation days, weekends, and public holidays in an intuitive interface.
 * Ideal for both local and distributed teams, enhancing team coordination and planning.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 * Manage teams and team members effectively.
 * Organize and track vacation days.
-* Keep a history of all day modifications.
+* Keep a history of all day modifications. Timestamps are shown in your local timezone.
 * Visualize vacation days, weekends, and public holidays in an intuitive interface.
 * Ideal for both local and distributed teams, enhancing team coordination and planning.
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,10 +10,10 @@ from typing import Annotated
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from fastapi import Depends, FastAPI, HTTPException, status
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.security import OAuth2PasswordRequestForm
 from fastapi import Form
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from fastapi.security import OAuth2PasswordRequestForm
 from prometheus_fastapi_instrumentator import Instrumentator
 from pydantic import BaseModel
 from pydantic.functional_validators import field_validator, model_validator
@@ -78,6 +78,7 @@ app.add_middleware(
 
 log = logging.getLogger(__name__)
 
+
 @app.get("/health", status_code=status.HTTP_200_OK)
 async def health_check():
     """
@@ -93,7 +94,6 @@ class GeneralApplicationConfigDTO(BaseModel):
     telegram_bot_username: str
     user_initiated: bool
     multitenancy_enabled: bool = False
-
 
 
 # General Application Configuration
@@ -214,5 +214,3 @@ async def telegram_login(auth_data: TelegramAuthData):
     )
 
     return TokenDTO(access_token=access_token, token_type="bearer")
-
-

--- a/backend/model.py
+++ b/backend/model.py
@@ -378,6 +378,27 @@ def get_unique_countries(tenant):
     return list(unique_countries)
 
 
+class DayAudit(Document):
+    tenant = ReferenceField(Tenant, required=True, reverse_delete_rule=mongoengine.CASCADE)
+    team = ReferenceField(Team, required=True, reverse_delete_rule=mongoengine.CASCADE)
+    member_uid = StringField(required=True)
+    date = DateField(required=True)
+    user = ReferenceField(User, required=True, reverse_delete_rule=mongoengine.NULLIFY)
+    timestamp = DateTimeField(required=True, default=lambda: datetime.now(timezone.utc))
+    old_day_types = ListField(ReferenceField(DayType))
+    old_comment = StringField(default='')
+    new_day_types = ListField(ReferenceField(DayType))
+    new_comment = StringField(default='')
+    action = StringField(required=True, choices=['created', 'updated', 'deleted'])
+
+    meta = {
+        "indexes": [
+            ("tenant", "team", "member_uid", "date"),
+        ],
+        "index_background": True,
+    }
+
+
 def get_team_id_and_member_uid_by_email(tenant, email):
     for team in Team.objects(tenant=tenant):
         for member in team.team_members:

--- a/backend/routers/teams.py
+++ b/backend/routers/teams.py
@@ -672,7 +672,7 @@ async def get_day_history(team_id: str, team_member_id: str, date: str,
         team=team,
         member_uid=str(team_member.uid),
         date=date_obj
-    ).order_by("timestamp")
+    ).order_by("-timestamp")
 
     return [mongo_to_pydantic(a, DayAuditDTO) for a in audits]
 

--- a/backend/test_day_audit.py
+++ b/backend/test_day_audit.py
@@ -1,0 +1,53 @@
+import os
+os.environ.setdefault("MONGO_MOCK", "1")
+os.environ.setdefault("AUTHENTICATION_SECRET_KEY", "test_secret")
+
+import datetime
+import uuid
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.model import Tenant, DayType, Team, TeamMember, User, AuthDetails, DayAudit
+from backend.dependencies import get_current_active_user_check_tenant, get_tenant
+
+client = TestClient(app)
+
+
+def setup_team():
+    tenant = Tenant(name=f"Tenant{uuid.uuid4()}", identifier=str(uuid.uuid4())).save()
+    DayType.init_day_types(tenant)
+    member = TeamMember(name="Alice", country="Sweden")
+    team = Team(tenant=tenant, name="Team", team_members=[member]).save()
+    user = User(tenants=[tenant], name="User", auth_details=AuthDetails(username=str(uuid.uuid4()))).save()
+    return team, member, user
+
+
+def test_update_days_creates_audit():
+    team, member, user = setup_team()
+    vac = DayType.objects(tenant=team.tenant, identifier="vacation").first()
+    day_type_id = str(vac.id)
+
+    app.dependency_overrides[get_current_active_user_check_tenant] = lambda: user
+
+    resp = client.put(
+        f"/teams/{team.id}/members/{member.uid}/days",
+        json={"2025-01-01": {"day_types": [day_type_id], "comment": "hello"}},
+        headers={"Tenant-ID": team.tenant.identifier},
+    )
+    assert resp.status_code == 200
+
+    audit = DayAudit.objects(tenant=team.tenant, team=team, member_uid=str(member.uid), date=datetime.date(2025,1,1)).first()
+    assert audit is not None
+    assert audit.action == "created"
+    assert [str(dt.id) for dt in audit.new_day_types] == [day_type_id]
+    hist_resp = client.get(
+        f"/teams/{team.id}/members/{member.uid}/days/2025-01-01/history",
+        headers={"Tenant-ID": team.tenant.identifier},
+    )
+    assert hist_resp.status_code == 200
+    history = hist_resp.json()
+    assert len(history) == 1
+    assert history[0]["action"] == "created"
+
+    app.dependency_overrides = {}

--- a/frontend/src/components/DayHistoryModal.css
+++ b/frontend/src/components/DayHistoryModal.css
@@ -1,0 +1,11 @@
+.day-history-entry {
+  margin-bottom: 10px;
+  border-bottom: 1px solid #eee;
+  padding-bottom: 5px;
+}
+
+.day-history-list {
+  max-height: 300px;
+  overflow-y: auto;
+}
+

--- a/frontend/src/components/DayHistoryModal.css
+++ b/frontend/src/components/DayHistoryModal.css
@@ -9,3 +9,13 @@
   overflow-y: auto;
 }
 
+.day-type-tag {
+  display: inline-block;
+  background-color: #f0f0f0;
+  border-radius: 4px;
+  padding: 2px 6px;
+  margin-right: 4px;
+  margin-bottom: 2px;
+  font-size: 0.85em;
+}
+

--- a/frontend/src/components/DayHistoryModal.css
+++ b/frontend/src/components/DayHistoryModal.css
@@ -19,3 +19,27 @@
   font-size: 0.85em;
 }
 
+.action-tag {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 2px 4px;
+  border-radius: 4px;
+  font-size: 0.75em;
+  text-transform: capitalize;
+}
+
+.action-created {
+  background-color: #d4edda;
+  color: #155724;
+}
+
+.action-deleted {
+  background-color: #f8d7da;
+  color: #721c24;
+}
+
+.action-updated {
+  background-color: #d1ecf1;
+  color: #0c5460;
+}
+

--- a/frontend/src/components/DayHistoryModal.jsx
+++ b/frontend/src/components/DayHistoryModal.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import Modal from './Modal';
 import { useApi } from '../hooks/useApi';
-import { format } from 'date-fns';
 import './DayHistoryModal.css';
 
 const DayHistoryModal = ({ isOpen, onClose, teamId, memberId, date }) => {
@@ -31,7 +30,16 @@ const DayHistoryModal = ({ isOpen, onClose, teamId, memberId, date }) => {
         {history.map((entry) => (
           <div key={entry._id || entry.id} className="day-history-entry">
             <div>
-              {format(new Date(entry.timestamp), 'yyyy-MM-dd HH:mm')} - {entry.user ? (entry.user.name || entry.user.username) : 'Unknown'}
+              {new Date(entry.timestamp).toLocaleString(undefined, {
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit',
+                hour: '2-digit',
+                minute: '2-digit',
+                hour12: false,
+                timeZoneName: 'short'
+              })}
+              {' '} - {entry.user ? (entry.user.name || entry.user.username) : 'Unknown'}
             </div>
             <div>Action: {entry.action}</div>
             {(entry.old_day_types.length > 0 || entry.old_comment) && (

--- a/frontend/src/components/DayHistoryModal.jsx
+++ b/frontend/src/components/DayHistoryModal.jsx
@@ -25,7 +25,7 @@ const DayHistoryModal = ({ isOpen, onClose, teamId, memberId, date }) => {
 
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
-      <h3>History for {date}</h3>
+      <h3>History for {date} ({history.length} {history.length === 1 ? 'item' : 'items'})</h3>
       <div className="day-history-list">
         {history.length === 0 && <p>No history found.</p>}
         {history.map((entry) => (

--- a/frontend/src/components/DayHistoryModal.jsx
+++ b/frontend/src/components/DayHistoryModal.jsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useState } from 'react';
+import Modal from './Modal';
+import { useApi } from '../hooks/useApi';
+import { format } from 'date-fns';
+import './DayHistoryModal.css';
+
+const DayHistoryModal = ({ isOpen, onClose, teamId, memberId, date }) => {
+  const { apiCall } = useApi();
+  const [history, setHistory] = useState([]);
+
+  useEffect(() => {
+    const fetchHistory = async () => {
+      if (!isOpen) return;
+      try {
+        const result = await apiCall(`/teams/${teamId}/members/${memberId}/days/${date}/history`, 'GET');
+        setHistory(result);
+      } catch (error) {
+        console.error('Error fetching day history:', error);
+      }
+    };
+    fetchHistory();
+  }, [isOpen, teamId, memberId, date]);
+
+  if (!isOpen) return null;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <h3>History for {date}</h3>
+      <div className="day-history-list">
+        {history.length === 0 && <p>No history found.</p>}
+        {history.map((entry) => (
+          <div key={entry._id || entry.id} className="day-history-entry">
+            <div>
+              {format(new Date(entry.timestamp), 'yyyy-MM-dd HH:mm')} - {entry.user ? entry.user.username : 'Unknown'}
+            </div>
+            <div>Action: {entry.action}</div>
+            {(entry.old_day_types.length > 0 || entry.old_comment) && (
+              <div>
+                Old: {entry.old_day_types.map((dt) => dt.name).join(', ')} {entry.old_comment}
+              </div>
+            )}
+            {(entry.new_day_types.length > 0 || entry.new_comment) && (
+              <div>
+                New: {entry.new_day_types.map((dt) => dt.name).join(', ')} {entry.new_comment}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </Modal>
+  );
+};
+
+export default DayHistoryModal;
+

--- a/frontend/src/components/DayHistoryModal.jsx
+++ b/frontend/src/components/DayHistoryModal.jsx
@@ -40,8 +40,8 @@ const DayHistoryModal = ({ isOpen, onClose, teamId, memberId, date }) => {
                 timeZoneName: 'short'
               })}
               {' '} - {entry.user ? (entry.user.name || entry.user.username) : 'Unknown'}
+              <span className={`action-tag action-${entry.action}`}>{entry.action.charAt(0).toUpperCase() + entry.action.slice(1)}</span>
             </div>
-            <div>Action: {entry.action}</div>
             {(entry.old_day_types.length > 0 || entry.old_comment) && (
               <div>
                 Old:{' '}

--- a/frontend/src/components/DayHistoryModal.jsx
+++ b/frontend/src/components/DayHistoryModal.jsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import React, {useEffect, useState} from 'react';
 import Modal from './Modal';
-import { useApi } from '../hooks/useApi';
+import {useApi} from '../hooks/useApi';
 import './DayHistoryModal.css';
+import {format} from 'date-fns';
 
-const DayHistoryModal = ({ isOpen, onClose, teamId, memberId, date }) => {
-  const { apiCall } = useApi();
+const DayHistoryModal = ({isOpen, onClose, teamId, memberId, date}) => {
+  const {apiCall} = useApi();
   const [history, setHistory] = useState([]);
 
   useEffect(() => {
@@ -30,17 +31,9 @@ const DayHistoryModal = ({ isOpen, onClose, teamId, memberId, date }) => {
         {history.map((entry) => (
           <div key={entry._id || entry.id} className="day-history-entry">
             <div>
-              {new Date(entry.timestamp).toLocaleString(undefined, {
-                year: 'numeric',
-                month: '2-digit',
-                day: '2-digit',
-                hour: '2-digit',
-                minute: '2-digit',
-                hour12: false,
-                timeZoneName: 'short'
-              })}
-              {' '} - {entry.user ? (entry.user.name || entry.user.username) : 'Unknown'}
-              <span className={`action-tag action-${entry.action}`}>{entry.action.charAt(0).toUpperCase() + entry.action.slice(1)}</span>
+              {format(new Date(entry.timestamp), 'yyyy-MM-dd HH:mm')} - {entry.user ? (entry.user.name || entry.user.username) : 'Unknown'}
+              <span
+                className={`action-tag action-${entry.action}`}>{entry.action.charAt(0).toUpperCase() + entry.action.slice(1)}</span>
             </div>
             {(entry.old_day_types.length > 0 || entry.old_comment) && (
               <div>

--- a/frontend/src/components/DayHistoryModal.jsx
+++ b/frontend/src/components/DayHistoryModal.jsx
@@ -31,7 +31,7 @@ const DayHistoryModal = ({ isOpen, onClose, teamId, memberId, date }) => {
         {history.map((entry) => (
           <div key={entry._id || entry.id} className="day-history-entry">
             <div>
-              {format(new Date(entry.timestamp), 'yyyy-MM-dd HH:mm')} - {entry.user ? entry.user.username : 'Unknown'}
+              {format(new Date(entry.timestamp), 'yyyy-MM-dd HH:mm')} - {entry.user ? (entry.user.name || entry.user.username) : 'Unknown'}
             </div>
             <div>Action: {entry.action}</div>
             {(entry.old_day_types.length > 0 || entry.old_comment) && (

--- a/frontend/src/components/DayHistoryModal.jsx
+++ b/frontend/src/components/DayHistoryModal.jsx
@@ -44,12 +44,20 @@ const DayHistoryModal = ({ isOpen, onClose, teamId, memberId, date }) => {
             <div>Action: {entry.action}</div>
             {(entry.old_day_types.length > 0 || entry.old_comment) && (
               <div>
-                Old: {entry.old_day_types.map((dt) => dt.name).join(', ')} {entry.old_comment}
+                Old:{' '}
+                {entry.old_day_types.map((dt) => (
+                  <span key={dt._id} className="day-type-tag">{dt.name}</span>
+                ))}
+                {entry.old_comment && <span>{entry.old_comment}</span>}
               </div>
             )}
             {(entry.new_day_types.length > 0 || entry.new_comment) && (
               <div>
-                New: {entry.new_day_types.map((dt) => dt.name).join(', ')} {entry.new_comment}
+                New:{' '}
+                {entry.new_day_types.map((dt) => (
+                  <span key={dt._id} className="day-type-tag">{dt.name}</span>
+                ))}
+                {entry.new_comment && <span>{entry.new_comment}</span>}
               </div>
             )}
           </div>

--- a/frontend/src/components/DayTypeContextMenu.css
+++ b/frontend/src/components/DayTypeContextMenu.css
@@ -42,3 +42,8 @@
   border-radius: 4px;
   font-size: 0.9em;
 }
+
+.history-icon {
+  margin-left: 5px;
+  cursor: pointer;
+}

--- a/frontend/src/components/DayTypeContextMenu.jsx
+++ b/frontend/src/components/DayTypeContextMenu.jsx
@@ -3,7 +3,10 @@ import './DayTypeContextMenu.css';
 import {useApi} from '../hooks/useApi';
 import {format, isWeekend} from 'date-fns';
 import {toast} from 'react-toastify';
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+import {faHistory} from '@fortawesome/free-solid-svg-icons';
 import DayTypeCheckbox from './DayTypeCheckbox';
+import DayHistoryModal from './DayHistoryModal';
 
 const DayTypeContextMenu = ({
                               contextMenuRef,
@@ -19,6 +22,7 @@ const DayTypeContextMenu = ({
   const [selectedDayTypes, setSelectedDayTypes] = useState([]);
   const [comment, setComment] = useState('');
   const [initialComment, setInitialComment] = useState('');
+  const [showHistory, setShowHistory] = useState(false);
   const {apiCall} = useApi();
 
   const visibleDayTypes =
@@ -86,6 +90,9 @@ const DayTypeContextMenu = ({
     }
   };
 
+  const openHistoryModal = () => setShowHistory(true);
+  const closeHistoryModal = () => setShowHistory(false);
+
   const updateDayData = async (dayTypes, comment) => {
     const baseTypeIds = selectedDayInfo.existingDayTypes.map((t) => t._id);
     const dayTypeData = {};
@@ -151,8 +158,16 @@ const DayTypeContextMenu = ({
   }
 
   return (
+    <>
     <div className="context-menu" style={contextMenuStyle} ref={contextMenuRef}>
-      {selectedDayInfo && <div className="display-date-info">{displayDate}</div>}
+      {selectedDayInfo && (
+        <div className="display-date-info">
+          {displayDate}
+          <span className="history-icon" onClick={openHistoryModal}>
+            <FontAwesomeIcon icon={faHistory}/>
+          </span>
+        </div>
+      )}
       <div className="close-button" onClick={onClose}>
         &times;
       </div>
@@ -210,6 +225,14 @@ const DayTypeContextMenu = ({
         })}
 
     </div>
+    <DayHistoryModal
+      isOpen={showHistory}
+      onClose={closeHistoryModal}
+      teamId={selectedDayInfo?.teamId}
+      memberId={selectedDayInfo?.memberId}
+      date={selectedDayInfo?.dateRange && selectedDayInfo.dateRange.length > 0 ? format(selectedDayInfo.dateRange[0], 'yyyy-MM-dd') : ''}
+    />
+    </>
   );
 };
 

--- a/frontend/src/components/DayTypeContextMenu.jsx
+++ b/frontend/src/components/DayTypeContextMenu.jsx
@@ -163,8 +163,8 @@ const DayTypeContextMenu = ({
       {selectedDayInfo && (
         <div className="display-date-info">
           {displayDate}
-          {selectedDayInfo.dateRange && selectedDayInfo.dateRange.length === 1 && (
-            <span className="history-icon" onClick={openHistoryModal}>
+            {selectedDayInfo.dateRange && selectedDayInfo.dateRange.length === 1 && (
+            <span className="history-icon" onClick={openHistoryModal} title="View history">
               <FontAwesomeIcon icon={faHistory}/>
             </span>
           )}

--- a/frontend/src/components/DayTypeContextMenu.jsx
+++ b/frontend/src/components/DayTypeContextMenu.jsx
@@ -163,9 +163,11 @@ const DayTypeContextMenu = ({
       {selectedDayInfo && (
         <div className="display-date-info">
           {displayDate}
-          <span className="history-icon" onClick={openHistoryModal}>
-            <FontAwesomeIcon icon={faHistory}/>
-          </span>
+          {selectedDayInfo.dateRange && selectedDayInfo.dateRange.length === 1 && (
+            <span className="history-icon" onClick={openHistoryModal}>
+              <FontAwesomeIcon icon={faHistory}/>
+            </span>
+          )}
         </div>
       )}
       <div className="close-button" onClick={onClose}>


### PR DESCRIPTION
## Summary
- track changes to team member days with new `DayAudit` document
- log updates and expose day history endpoint
- document history feature
- add regression test for day audit creation
- add frontend day history modal and icon

## Testing
- `npm test --prefix frontend -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688784efcf488320b64d27b472ed7182