### PR TITLE
Update day history tag colors

### DIFF
--- a/frontend/src/components/DayHistoryModal.css
+++ b/frontend/src/components/DayHistoryModal.css
@@ -11,7 +11,6 @@
 
 .day-type-tag {
   display: inline-block;
-  background-color: #f0f0f0;
   border-radius: 4px;
   padding: 2px 6px;
   margin-right: 4px;

--- a/frontend/src/components/DayHistoryModal.jsx
+++ b/frontend/src/components/DayHistoryModal.jsx
@@ -39,7 +39,9 @@ const DayHistoryModal = ({isOpen, onClose, teamId, memberId, date}) => {
               <div>
                 Old:{' '}
                 {entry.old_day_types.map((dt) => (
-                  <span key={dt._id} className="day-type-tag">{dt.name}</span>
+                  <span key={dt._id} className="day-type-tag" style={{backgroundColor: dt.color}}>
+                    {dt.name}
+                  </span>
                 ))}
                 {entry.old_comment && <span>{entry.old_comment}</span>}
               </div>
@@ -48,7 +50,9 @@ const DayHistoryModal = ({isOpen, onClose, teamId, memberId, date}) => {
               <div>
                 New:{' '}
                 {entry.new_day_types.map((dt) => (
-                  <span key={dt._id} className="day-type-tag">{dt.name}</span>
+                  <span key={dt._id} className="day-type-tag" style={{backgroundColor: dt.color}}>
+                    {dt.name}
+                  </span>
                 ))}
                 {entry.new_comment && <span>{entry.new_comment}</span>}
               </div>


### PR DESCRIPTION
## Summary
- color the day type tags in DayHistoryModal using configured day type color
- remove static grey background from tag styles

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6888ed2a75a083209cce94047c7ffd38