### PR TITLE
Implement diff view in day history modal

### DIFF
--- a/frontend/src/components/DayHistoryModal.css
+++ b/frontend/src/components/DayHistoryModal.css
@@ -49,7 +49,6 @@
   table-layout: fixed;
 }
 
-.diff-table th,
 .diff-table td {
   width: 50%;
   padding: 4px 8px;
@@ -58,9 +57,19 @@
   border: 1px solid #d0d7de;
 }
 
-.diff-table th {
-  background-color: #f6f8fa;
-  font-weight: 600;
-  text-align: left;
+.diff-container {
+  position: relative;
+}
+
+.diff-arrow {
+  position: absolute;
+  top: -8px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 12px;
+  color: #666;
+  background: #fff;
+  padding: 0 2px;
+  pointer-events: none;
 }
 

--- a/frontend/src/components/DayHistoryModal.jsx
+++ b/frontend/src/components/DayHistoryModal.jsx
@@ -55,14 +55,10 @@ const DayHistoryModal = ({isOpen, onClose, teamId, memberId, date}) => {
                   className={`action-tag action-${entry.action}`}>{entry.action.charAt(0).toUpperCase() + entry.action.slice(1)}</span>
               </div>
               {showDiff && (
-                <table className="diff-table">
-                  <thead>
-                  <tr>
-                    <th>Old</th>
-                    <th>New</th>
-                  </tr>
-                  </thead>
-                  <tbody>
+                <div className="diff-container">
+                  <span className="diff-arrow">&rarr;</span>
+                  <table className="diff-table">
+                    <tbody>
                   {showDayTypesRow && (
                     <tr>
                       <td>
@@ -87,8 +83,9 @@ const DayHistoryModal = ({isOpen, onClose, teamId, memberId, date}) => {
                       <td>{entry.new_comment}</td>
                     </tr>
                   )}
-                  </tbody>
-                </table>
+                    </tbody>
+                  </table>
+                </div>
               )}
             </div>
           );


### PR DESCRIPTION
## Summary
- add diff split table for day history entries
- style the diff table with equal column widths

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6888f0644cac83208fd9b6dab20a7383