### PR TITLE
Add closing cross to DayHistoryModal

### DIFF
--- a/frontend/src/components/DayHistoryModal.css
+++ b/frontend/src/components/DayHistoryModal.css
@@ -73,3 +73,23 @@
   pointer-events: none;
 }
 
+.day-history-modal {
+  position: relative;
+}
+
+.day-history-modal .close-button {
+  position: absolute;
+  top: 0px;
+  right: 0px;
+  cursor: pointer;
+  font-size: 20px;
+  color: #333;
+  padding: 3px;
+  background-color: rgba(255, 255, 255, 0.9);
+  border-radius: 50%;
+  line-height: 1;
+  text-align: center;
+  width: 20px;
+  height: 20px;
+}
+

--- a/frontend/src/components/DayHistoryModal.jsx
+++ b/frontend/src/components/DayHistoryModal.jsx
@@ -25,10 +25,12 @@ const DayHistoryModal = ({isOpen, onClose, teamId, memberId, date}) => {
 
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
-      <h3>History for {date} ({history.length} {history.length === 1 ? 'item' : 'items'})</h3>
-      <div className="day-history-list">
-        {history.length === 0 && <p>No history found.</p>}
-        {history.map((entry) => {
+      <div className="day-history-modal">
+        <div className="close-button" onClick={onClose}>&times;</div>
+        <h3>History for {date} ({history.length} {history.length === 1 ? 'item' : 'items'})</h3>
+        <div className="day-history-list">
+          {history.length === 0 && <p>No history found.</p>}
+          {history.map((entry) => {
           const dayTypesEqual = () => {
             if (entry.old_day_types.length !== entry.new_day_types.length) return false;
             const oldIds = entry.old_day_types.map((dt) => dt._id || dt.id).sort();
@@ -90,6 +92,7 @@ const DayHistoryModal = ({isOpen, onClose, teamId, memberId, date}) => {
             </div>
           );
         })}
+        </div>
       </div>
     </Modal>
   );


### PR DESCRIPTION
## Summary
- add a close button to `DayHistoryModal`
- style the modal to position the cross like the context menu

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68890b409c0c8320a3974864f83d08c6