### PR TITLE
Hide user existence in password reset flow

### DIFF
--- a/frontend/src/components/auth/PasswordResetRequest.jsx
+++ b/frontend/src/components/auth/PasswordResetRequest.jsx
@@ -14,7 +14,7 @@ const PasswordResetRequest = () => {
     e.preventDefault();
     try {
       await apiCall('/users/password-reset/request', 'POST', {email});
-      toast.success('Password reset email sent');
+      toast.success('If the email is registered, you will receive a password reset email');
       navigate('/login');
     } catch (error) {
       if (error.data && error.data.detail) {


### PR DESCRIPTION
## Summary
- Return generic message for password reset requests and send email only if user exists
- Update password reset tests for generic response and unknown email
- Show generic success toast on password reset request page

## Testing
- `pytest backend`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689a064764888320855c82421f8a38e5