### PR TITLE
refactor: organize backend tests

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+
+os.environ.setdefault("MONGO_MOCK", "1")
+os.environ.setdefault("AUTHENTICATION_SECRET_KEY", "test_secret")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "testtoken")
+os.environ.setdefault("TELEGRAM_BOT_USERNAME", "testbot")

--- a/backend/tests/test_calendar.py
+++ b/backend/tests/test_calendar.py
@@ -1,11 +1,8 @@
-import os
-os.environ.setdefault("MONGO_MOCK", "1")
-os.environ.setdefault("AUTHENTICATION_SECRET_KEY", "test_secret")
-
 from fastapi.testclient import TestClient
 import uuid
-from .main import app
-from .model import Tenant, DayType, Team, TeamMember, DayEntry, User, AuthDetails
+
+from backend.main import app
+from backend.model import Tenant, DayType, Team, TeamMember, DayEntry, User, AuthDetails
 
 client = TestClient(app)
 

--- a/backend/tests/test_day_audit.py
+++ b/backend/tests/test_day_audit.py
@@ -1,7 +1,3 @@
-import os
-os.environ.setdefault("MONGO_MOCK", "1")
-os.environ.setdefault("AUTHENTICATION_SECRET_KEY", "test_secret")
-
 import datetime
 import uuid
 

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -1,11 +1,9 @@
-import os
-os.environ.setdefault("MONGO_MOCK", "1")
-os.environ.setdefault("AUTHENTICATION_SECRET_KEY", "test_secret")
-
 from fastapi.testclient import TestClient
+
 from openpyxl import load_workbook
-from .main import app
-from .model import Tenant, DayType, Team, TeamMember, DayEntry, User
+from backend.main import app
+from backend.model import Tenant, DayType, Team, TeamMember, DayEntry, User
+from backend.dependencies import get_current_active_user_check_tenant, get_tenant
 import uuid
 
 client = TestClient(app)
@@ -22,9 +20,6 @@ def setup_teams():
     team2 = Team(tenant=tenant, name="Team2", team_members=[member2])
     team2.save()
     return team1, team2
-
-
-from backend.dependencies import get_current_active_user_check_tenant, get_tenant
 
 
 def test_export_selected_team():

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,13 +1,8 @@
 from unittest.mock import patch
-import os
-
-# Use an in-memory MongoDB for tests
-os.environ.setdefault("MONGO_MOCK", "1")
-os.environ.setdefault("AUTHENTICATION_SECRET_KEY", "test_secret")
 
 from fastapi.testclient import TestClient
-from .main import app
-from .model import User, AuthDetails
+from backend.main import app
+from backend.model import User, AuthDetails
 import pytest
 
 client = TestClient(app)

--- a/backend/tests/test_mfa.py
+++ b/backend/tests/test_mfa.py
@@ -1,12 +1,7 @@
-import os
-os.environ.setdefault("MONGO_MOCK", "1")
-os.environ.setdefault("AUTHENTICATION_SECRET_KEY", "test_secret")
-
 import pyotp
 from fastapi.testclient import TestClient
-
-from .main import app
-from .model import Tenant, User, AuthDetails
+from backend.main import app
+from backend.model import Tenant, User, AuthDetails
 import uuid
 
 client = TestClient(app)

--- a/backend/tests/test_password_hashing.py
+++ b/backend/tests/test_password_hashing.py
@@ -1,7 +1,3 @@
-import os
-os.environ.setdefault("MONGO_MOCK", "1")
-os.environ.setdefault("AUTHENTICATION_SECRET_KEY", "test_secret")
-
 import uuid
 from backend.model import Tenant, User, AuthDetails
 from pwdlib.hashers.bcrypt import BcryptHasher

--- a/backend/tests/test_password_reset.py
+++ b/backend/tests/test_password_reset.py
@@ -1,13 +1,9 @@
-import os
-os.environ.setdefault("MONGO_MOCK", "1")
-os.environ.setdefault("AUTHENTICATION_SECRET_KEY", "test_secret")
-
 import hashlib
 from unittest.mock import patch
 from fastapi.testclient import TestClient
 
-from .main import app
-from .model import Tenant, User, AuthDetails, PasswordResetToken
+from backend.main import app
+from backend.model import Tenant, User, AuthDetails, PasswordResetToken
 
 client = TestClient(app)
 

--- a/backend/tests/test_telegram_login.py
+++ b/backend/tests/test_telegram_login.py
@@ -1,16 +1,10 @@
-import os
 import time
 import hashlib
 import hmac
 
-os.environ.setdefault("MONGO_MOCK", "1")
-os.environ.setdefault("AUTHENTICATION_SECRET_KEY", "test_secret")
-os.environ.setdefault("TELEGRAM_BOT_TOKEN", "testtoken")
-os.environ.setdefault("TELEGRAM_BOT_USERNAME", "testbot")
-
 from fastapi.testclient import TestClient
-from .main import app, TELEGRAM_BOT_TOKEN
-from .model import User, AuthDetails
+from backend.main import app, TELEGRAM_BOT_TOKEN
+from backend.model import User, AuthDetails
 
 client = TestClient(app)
 

--- a/backend/tests/test_upcoming_vacation.py
+++ b/backend/tests/test_upcoming_vacation.py
@@ -1,7 +1,3 @@
-import os
-os.environ.setdefault("MONGO_MOCK", "1")
-os.environ.setdefault("AUTHENTICATION_SECRET_KEY", "test_secret")
-
 import datetime
 import uuid
 from unittest.mock import patch

--- a/backend/tests/test_vacation_days_available.py
+++ b/backend/tests/test_vacation_days_available.py
@@ -1,16 +1,10 @@
-import os
-
-from backend.routers.teams import TeamMemberReadDTO
-
-os.environ.setdefault("MONGO_MOCK", "1")
-os.environ.setdefault("AUTHENTICATION_SECRET_KEY", "test_secret")
-
 import datetime
 from unittest.mock import patch
+import uuid
+from backend.routers.teams import TeamMemberReadDTO
 
 from backend.model import Tenant, DayType, TeamMember, DayEntry
 from backend.dependencies import mongo_to_pydantic, tenant_var
-import uuid
 
 
 def setup_member(days=None):


### PR DESCRIPTION
## Summary
- move all backend tests into dedicated `backend/tests` package
- share test environment configuration via `conftest.py`
- update imports to use package paths

## Testing
- `pytest backend`

------
https://chatgpt.com/codex/tasks/task_e_689ee884185c83208d9be972efacb35e