### PR TITLE
chore: reorganize backend tests

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -27,7 +27,7 @@ pytest backend
   Update any tests affected by your changes: adjust assertions or setup, refactor, or remove obsolete tests.
 
 * **Best practices**
-  * Tests should reside in the same package as the module they test.
+  * Store tests under `backend/tests`, using subdirectories that mirror the application's modules.
   * Use pytest fixtures and mocks to isolate external dependencies.
   * Give tests clear, descriptive names.
   * Keep tests fast, deterministic, and focused on a single behavior.

--- a/backend/tests/db_migrations/test_invite_token_migration.py
+++ b/backend/tests/db_migrations/test_invite_token_migration.py
@@ -6,7 +6,7 @@ import importlib
 
 os.environ.setdefault("MONGO_MOCK", "1")
 
-from . import db_utils
+from backend.db_migrations import db_utils
 
 
 def test_hash_pending_invite_tokens_migration():

--- a/backend/tests/db_migrations/test_password_reset_token_migration.py
+++ b/backend/tests/db_migrations/test_password_reset_token_migration.py
@@ -6,7 +6,7 @@ import importlib
 
 os.environ.setdefault("MONGO_MOCK", "1")
 
-from . import db_utils
+from backend.db_migrations import db_utils
 
 
 def test_hash_pending_password_reset_tokens_migration():

--- a/backend/tests/routers/test_user_invite.py
+++ b/backend/tests/routers/test_user_invite.py
@@ -6,8 +6,8 @@ from fastapi.testclient import TestClient
 os.environ.setdefault("MONGO_MOCK", "1")
 os.environ.setdefault("AUTHENTICATION_SECRET_KEY", "test_secret")
 
-from ..main import app
-from ..model import Tenant, User, AuthDetails, UserInvite
+from backend.main import app
+from backend.model import Tenant, User, AuthDetails, UserInvite
 import pyotp
 
 client = TestClient(app)

--- a/backend/tests/routers/test_users.py
+++ b/backend/tests/routers/test_users.py
@@ -9,8 +9,8 @@ import pytest
 from bson.objectid import ObjectId
 from fastapi.testclient import TestClient
 
-from ..main import app
-from ..model import User, AuthDetails, Tenant
+from backend.main import app
+from backend.model import User, AuthDetails, Tenant
 
 client = TestClient(app)
 

--- a/backend/tests/scheduled/test_vacation_starts.py
+++ b/backend/tests/scheduled/test_vacation_starts.py
@@ -6,7 +6,10 @@ import os
 os.environ.setdefault("MONGO_MOCK", "1")
 os.environ.setdefault("AUTHENTICATION_SECRET_KEY", "test_secret")
 
-from .vacation_starts import get_next_working_day, only_for_team_member
+from backend.scheduled.vacation_starts import (
+    get_next_working_day,
+    only_for_team_member,
+)
 
 
 def test_get_next_working_day():


### PR DESCRIPTION
## Summary
- centralize backend tests under `backend/tests` to declutter source packages
- update test imports and instructions to reflect new layout

## Testing
- `pip install -r backend/requirements.txt`
- `pip install httpx`
- `pytest backend`


------
https://chatgpt.com/codex/tasks/task_e_689f14198bd88320b3c9aa3fcd515e24