### PR TITLE
feat: add API key management

### DIFF
--- a/backend/tests/test_api_key.py
+++ b/backend/tests/test_api_key.py
@@ -1,0 +1,56 @@
+import uuid
+import pyotp
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.model import Tenant, User, AuthDetails
+
+client = TestClient(app)
+
+
+def create_user():
+    tenant = Tenant(name=str(uuid.uuid4()), identifier=str(uuid.uuid4())).save()
+    username = str(uuid.uuid4())
+    email = f"{username}@example.com"
+    user = User(tenants=[tenant], name="User", email=email,
+                auth_details=AuthDetails(username=username))
+    user.hash_password("pass")
+    user.save()
+    return user
+
+
+def auth_headers(user):
+    resp = client.post(
+        "/token",
+        data={"username": user.auth_details.username, "password": "pass"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    totp = pyotp.TOTP(user.auth_details.mfa_secret)
+    code = totp.now()
+    resp = client.post(
+        "/token",
+        data={"username": user.auth_details.username, "password": "pass", "otp": code},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    token = resp.json()["access_token"]
+    return {"Authorization": f"Bearer {token}", "Tenant-ID": user.tenants[0].identifier}
+
+
+def test_get_and_regenerate_api_key():
+    user = create_user()
+    headers = auth_headers(user)
+    old_key = user.auth_details.api_key
+
+    resp = client.get("/users/me/api-key", headers=headers)
+    assert resp.status_code == 200
+    masked = resp.json()["api_key"]
+    assert masked.startswith(old_key[:4])
+    assert masked.endswith(old_key[-4:])
+    assert "*" in masked
+
+    resp = client.post("/users/me/api-key", headers=headers)
+    assert resp.status_code == 200
+    new_key = resp.json()["api_key"]
+    assert new_key != old_key
+    user.reload()
+    assert user.auth_details.api_key == new_key

--- a/frontend/src/components/settings/ApiKeyModal.jsx
+++ b/frontend/src/components/settings/ApiKeyModal.jsx
@@ -1,0 +1,69 @@
+import React, {useEffect, useState} from 'react';
+import Modal from '../Modal';
+import {useApi} from '../../hooks/useApi';
+import {toast} from 'react-toastify';
+
+const ApiKeyModal = ({isOpen, onClose}) => {
+  const {apiCall} = useApi();
+  const [apiKey, setApiKey] = useState('');
+  const [isMasked, setIsMasked] = useState(true);
+
+  useEffect(() => {
+    if (isOpen) {
+      const fetchKey = async () => {
+        try {
+          const data = await apiCall('/users/me/api-key');
+          setApiKey(data.api_key);
+          setIsMasked(true);
+        } catch (e) {
+          console.error('Error fetching API key:', e);
+          toast.error('Error fetching API key');
+        }
+      };
+      fetchKey();
+    }
+  }, [isOpen]);
+
+  const handleRegenerate = async () => {
+    const confirmed = window.confirm('Regenerate API key?');
+    if (!confirmed) return;
+    try {
+      const data = await apiCall('/users/me/api-key', 'POST');
+      setApiKey(data.api_key);
+      setIsMasked(false);
+      toast.success('API key regenerated');
+    } catch (e) {
+      console.error('Error regenerating API key:', e);
+      toast.error('Error regenerating API key');
+    }
+  };
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(apiKey);
+      toast('API key copied to clipboard');
+    } catch (e) {
+      console.error('Failed to copy API key:', e);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <div className="apiKeyModal">
+        <p>API Key: <span className="apiKey" style={{cursor: !isMasked ? 'pointer' : 'default'}} onClick={!isMasked ? handleCopy : undefined}>{apiKey}</span></p>
+        <div className="button-container">
+          {isMasked ? (
+            <button type="button" onClick={handleRegenerate}>Regenerate</button>
+          ) : (
+            <button type="button" onClick={handleCopy}>Copy</button>
+          )}
+          <button type="button" onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default ApiKeyModal;

--- a/frontend/src/components/settings/UserManagement.jsx
+++ b/frontend/src/components/settings/UserManagement.jsx
@@ -2,10 +2,11 @@ import React, {useEffect, useState} from 'react';
 import {useApi} from '../../hooks/useApi';
 import UserModal from './UserModal';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
-import {faEdit, faKey, faTrashAlt, faSyncAlt} from '@fortawesome/free-solid-svg-icons';
+import {faEdit, faKey, faTrashAlt, faSyncAlt, faLock} from '@fortawesome/free-solid-svg-icons';
 import {useAuth} from "../../contexts/AuthContext";
 import {toast} from 'react-toastify';
 import PasswordChangeModal from "./PasswordChangeModal";
+import ApiKeyModal from './ApiKeyModal';
 import InviteUserModal from './InviteUserModal';
 import InviteManagement from './InviteManagement';
 import {useLocation, useNavigate} from "react-router-dom";
@@ -19,6 +20,7 @@ const UserManagement = () => {
   const [showUserModal, setShowUserModal] = useState(false);
   const [showInviteModal, setShowInviteModal] = useState(false);
   const [showPasswordModal, setShowPasswordModal] = useState(false);
+  const [showApiKeyModal, setShowApiKeyModal] = useState(false);
   const [editingUser, setEditingUser] = useState(null);
   const [refreshInvites, setRefreshInvites] = useState(false);
 
@@ -94,6 +96,10 @@ const UserManagement = () => {
     setShowPasswordModal(true);
   };
 
+  const handleApiKeyClick = () => {
+    setShowApiKeyModal(true);
+  };
+
   const handleResetMfa = async (userId, userName) => {
     const isConfirmed = window.confirm(`Reset MFA for ${userName}?`);
     if (isConfirmed) {
@@ -157,12 +163,20 @@ const UserManagement = () => {
                                title="Reset MFA"
                                aria-label="Reset MFA"/>
               {u._id === user._id && (
-                <FontAwesomeIcon icon={faKey}
-                                 onClick={() => handlePasswordChangeClick(u)}
-                                 className="actionIcon"
-                                 title="Change password"
-                                 aria-label="Change password"
-                />
+                <>
+                  <FontAwesomeIcon icon={faLock}
+                                   onClick={() => handlePasswordChangeClick(u)}
+                                   className="actionIcon"
+                                   title="Change password"
+                                   aria-label="Change password"
+                  />
+                  <FontAwesomeIcon icon={faKey}
+                                   onClick={handleApiKeyClick}
+                                   className="actionIcon"
+                                   title="Show API key"
+                                   aria-label="Show API key"
+                  />
+                </>
               )}
             </td>
           </tr>
@@ -186,6 +200,12 @@ const UserManagement = () => {
         <PasswordChangeModal
           isOpen={showPasswordModal}
           onClose={() => setShowPasswordModal(false)}
+        />
+      )}
+      {showApiKeyModal && (
+        <ApiKeyModal
+          isOpen={showApiKeyModal}
+          onClose={() => setShowApiKeyModal(false)}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- allow users to view and regenerate their API key
- add API key modal and action in settings
- implement backend endpoints with tests

## Testing
- `pytest backend`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a40ed5cc64832085791830a3516875