### PR TITLE
Add member history view and API endpoint

### DIFF
--- a/backend/tests/test_day_audit.py
+++ b/backend/tests/test_day_audit.py
@@ -60,4 +60,14 @@ def test_update_days_creates_audit():
     assert history[0]["action"] == "updated"
     assert history[1]["action"] == "created"
 
+    member_hist_resp = client.get(
+        f"/teams/{team.id}/members/{member.uid}/history",
+        headers={"Tenant-ID": team.tenant.identifier},
+    )
+    assert member_hist_resp.status_code == 200
+    member_history = member_hist_resp.json()
+    assert len(member_history) == 2
+    assert member_history[0]["action"] == "updated"
+    assert member_history[1]["action"] == "created"
+
     app.dependency_overrides = {}

--- a/frontend/src/components/CalendarComponent.css
+++ b/frontend/src/components/CalendarComponent.css
@@ -140,7 +140,8 @@
 .member-name-cell .drag-icon,
 .member-name-cell .edit-icon,
 .member-name-cell .delete-icon,
-.member-name-cell .info-icon {
+.member-name-cell .info-icon,
+.member-name-cell .history-icon {
     visibility: hidden;
 }
 
@@ -152,7 +153,8 @@
 .member-name-cell:hover .drag-icon,
 .member-name-cell:hover .edit-icon,
 .member-name-cell:hover .delete-icon,
-.member-name-cell:hover .info-icon {
+.member-name-cell:hover .info-icon,
+.member-name-cell:hover .history-icon {
     visibility: visible;
 }
 
@@ -205,6 +207,12 @@
 .info-icon {
     margin-left: 10px;
     cursor: help;
+    color: grey;
+}
+
+.history-icon {
+    margin-left: 10px;
+    cursor: pointer;
     color: grey;
 }
 

--- a/frontend/src/components/CalendarComponent.jsx
+++ b/frontend/src/components/CalendarComponent.jsx
@@ -9,6 +9,7 @@ import {
   faEye,
   faGripVertical,
   faInfoCircle,
+  faHistory,
   faLink,
   faSave,
   faTrashAlt
@@ -20,6 +21,7 @@ import MonthSelector from './MonthSelector';
 import TeamModal from './TeamModal';
 import MemberModal from './MemberModal';
 import DayTypeContextMenu from './DayTypeContextMenu';
+import MemberHistoryModal from './MemberHistoryModal';
 import {useApi} from '../hooks/useApi';
 import {useAuth} from '../contexts/AuthContext';
 import {useTeamSubscription} from '../hooks/useTeamSubscription';
@@ -47,6 +49,8 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
   const [editingTeam, setEditingTeam] = useState(null);
   const [editingMember, setEditingMember] = useState(null);
   const [selectedDayInfo, setSelectedDayInfo] = useState(null);
+  const [showMemberHistory, setShowMemberHistory] = useState(false);
+  const [memberHistoryInfo, setMemberHistoryInfo] = useState({teamId: null, memberId: null, memberName: ''});
   const contextMenuRef = useRef(null);
   const [contextMenuPosition, setContextMenuPosition] = useState({x: 0, y: 0});
   const [showContextMenu, setShowContextMenu] = useState(false);
@@ -157,6 +161,11 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
 
     setSelectionStart(null);
     setSelectionDayTypes([]);
+  };
+
+  const openMemberHistory = (teamId, member) => {
+    setMemberHistoryInfo({teamId, memberId: member.uid, memberName: member.name});
+    setShowMemberHistory(true);
   };
 
 
@@ -575,6 +584,13 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
         updateTeamData={updateTeamData}
         editingMember={editingMember}
       />
+      <MemberHistoryModal
+        isOpen={showMemberHistory}
+        onClose={() => setShowMemberHistory(false)}
+        teamId={memberHistoryInfo.teamId}
+        memberId={memberHistoryInfo.memberId}
+        memberName={memberHistoryInfo.memberName}
+      />
       <DayTypeContextMenu
         contextMenuRef={contextMenuRef}
         isOpen={showContextMenu}
@@ -712,6 +728,9 @@ const CalendarComponent = ({serverTeamData, holidays, dayTypes, updateTeamData})
                         {member.name} <span title={member.country}>{member.country_flag}</span>
                         <span className="info-icon">
                             <FontAwesomeIcon icon={faInfoCircle} title={renderVacationDaysTooltip(member)}/>
+                        </span>
+                        <span className="history-icon" onClick={() => openMemberHistory(team._id, member)} title="View history">
+                          <FontAwesomeIcon icon={faHistory}/>
                         </span>
                         <span
                           className="drag-icon"

--- a/frontend/src/components/HistoryList.jsx
+++ b/frontend/src/components/HistoryList.jsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import {format} from 'date-fns';
+
+const HistoryList = ({history, showDate = false}) => (
+  <div className="day-history-list">
+    {history.length === 0 && <p>No history found.</p>}
+    {history.map((entry) => {
+      const dayTypesEqual = () => {
+        if (entry.old_day_types.length !== entry.new_day_types.length) return false;
+        const oldIds = entry.old_day_types.map((dt) => dt._id || dt.id).sort();
+        const newIds = entry.new_day_types.map((dt) => dt._id || dt.id).sort();
+        return oldIds.every((id, idx) => id === newIds[idx]);
+      };
+
+      const showDayTypesRow =
+        (entry.old_day_types.length > 0 || entry.new_day_types.length > 0) &&
+        !dayTypesEqual();
+
+      const showCommentsRow =
+        ((entry.old_comment && entry.old_comment !== '') ||
+          (entry.new_comment && entry.new_comment !== '')) &&
+        entry.old_comment !== entry.new_comment;
+
+      const showDiff = showDayTypesRow || showCommentsRow;
+
+      return (
+        <div key={entry._id || entry.id} className="day-history-entry">
+          <div>
+            {format(new Date(entry.timestamp), 'yyyy-MM-dd HH:mm')}
+            {showDate && ` [${entry.date}]`} - {entry.user ? (entry.user.name || entry.user.username) : 'Unknown'}
+            <span className={`action-tag action-${entry.action}`}>
+              {entry.action.charAt(0).toUpperCase() + entry.action.slice(1)}
+            </span>
+          </div>
+          {showDiff && (
+            <div className="diff-container">
+              <span className="diff-arrow">&rarr;</span>
+              <table className="diff-table">
+                <tbody>
+                  {showDayTypesRow && (
+                    <tr>
+                      <td>
+                        {entry.old_day_types.map((dt) => (
+                          <span
+                            key={dt._id || dt.id}
+                            className="day-type-tag"
+                            style={{backgroundColor: dt.color}}
+                          >
+                            {dt.name}
+                          </span>
+                        ))}
+                      </td>
+                      <td>
+                        {entry.new_day_types.map((dt) => (
+                          <span
+                            key={dt._id || dt.id}
+                            className="day-type-tag"
+                            style={{backgroundColor: dt.color}}
+                          >
+                            {dt.name}
+                          </span>
+                        ))}
+                      </td>
+                    </tr>
+                  )}
+                  {showCommentsRow && (
+                    <tr>
+                      <td>{entry.old_comment}</td>
+                      <td>{entry.new_comment}</td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      );
+    })}
+  </div>
+);
+
+export default HistoryList;

--- a/frontend/src/components/MemberHistoryModal.jsx
+++ b/frontend/src/components/MemberHistoryModal.jsx
@@ -4,7 +4,7 @@ import {useApi} from '../hooks/useApi';
 import './DayHistoryModal.css';
 import HistoryList from './HistoryList';
 
-const DayHistoryModal = ({isOpen, onClose, teamId, memberId, date}) => {
+const MemberHistoryModal = ({isOpen, onClose, teamId, memberId, memberName}) => {
   const {apiCall} = useApi();
   const [history, setHistory] = useState([]);
 
@@ -12,14 +12,14 @@ const DayHistoryModal = ({isOpen, onClose, teamId, memberId, date}) => {
     const fetchHistory = async () => {
       if (!isOpen) return;
       try {
-        const result = await apiCall(`/teams/${teamId}/members/${memberId}/days/${date}/history`, 'GET');
+        const result = await apiCall(`/teams/${teamId}/members/${memberId}/history`, 'GET');
         setHistory(result);
       } catch (error) {
-        console.error('Error fetching day history:', error);
+        console.error('Error fetching member history:', error);
       }
     };
     fetchHistory();
-  }, [isOpen, teamId, memberId, date]);
+  }, [isOpen, teamId, memberId]);
 
   if (!isOpen) return null;
 
@@ -27,11 +27,11 @@ const DayHistoryModal = ({isOpen, onClose, teamId, memberId, date}) => {
     <Modal isOpen={isOpen} onClose={onClose}>
       <div className="day-history-modal">
         <div className="close-button" onClick={onClose}>&times;</div>
-        <h3>History for {date} ({history.length} {history.length === 1 ? 'item' : 'items'})</h3>
-        <HistoryList history={history} />
+        <h3>History for {memberName} ({history.length} {history.length === 1 ? 'item' : 'items'})</h3>
+        <HistoryList history={history} showDate />
       </div>
     </Modal>
   );
 };
 
-export default DayHistoryModal;
+export default MemberHistoryModal;


### PR DESCRIPTION
## Summary
- add API endpoint to retrieve history for a team member
- include member history modal and icon in calendar view
- cover member history in backend tests
- reuse shared HistoryList component across day and member history modals

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a427263c308320801bcb77e98b38b6