### PR TITLE
Add paginated member and day history with infinite scroll

### DIFF
--- a/backend/tests/test_day_audit.py
+++ b/backend/tests/test_day_audit.py
@@ -1,6 +1,7 @@
 import datetime
 import uuid
 
+import pytest
 from fastapi.testclient import TestClient
 
 from backend.main import app
@@ -69,5 +70,59 @@ def test_update_days_creates_audit():
     assert len(member_history) == 2
     assert member_history[0]["action"] == "updated"
     assert member_history[1]["action"] == "created"
+
+    app.dependency_overrides = {}
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "/teams/{team_id}/members/{member_uid}/history",
+        "/teams/{team_id}/members/{member_uid}/days/2025-01-01/history",
+    ],
+)
+def test_history_pagination(endpoint):
+    team, member, user = setup_team()
+    app.dependency_overrides[get_current_active_user_check_tenant] = lambda: user
+
+    for i in range(120):
+        DayAudit(
+            tenant=team.tenant,
+            team=team,
+            member_uid=str(member.uid),
+            date=datetime.date(2025, 1, 1),
+            user=user,
+            timestamp=datetime.datetime.utcnow() + datetime.timedelta(minutes=i),
+            old_day_types=[],
+            new_day_types=[],
+            old_comment="",
+            new_comment="",
+            action="updated",
+        ).save()
+
+    url = endpoint.format(team_id=team.id, member_uid=member.uid)
+
+    resp = client.get(
+        url,
+        headers={"Tenant-ID": team.tenant.identifier},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 100
+
+    resp2 = client.get(
+        f"{url}?skip=100",
+        headers={"Tenant-ID": team.tenant.identifier},
+    )
+    assert resp2.status_code == 200
+    data2 = resp2.json()
+    assert len(data2) == 20
+
+    resp3 = client.get(
+        f"{url}?skip=200",
+        headers={"Tenant-ID": team.tenant.identifier},
+    )
+    assert resp3.status_code == 200
+    assert resp3.json() == []
 
     app.dependency_overrides = {}

--- a/frontend/src/components/DayHistoryModal.jsx
+++ b/frontend/src/components/DayHistoryModal.jsx
@@ -1,25 +1,12 @@
-import React, {useEffect, useState} from 'react';
+import React from 'react';
 import Modal from './Modal';
-import {useApi} from '../hooks/useApi';
 import './DayHistoryModal.css';
 import HistoryList from './HistoryList';
+import {usePaginatedHistory} from '../hooks/usePaginatedHistory';
 
 const DayHistoryModal = ({isOpen, onClose, teamId, memberId, date}) => {
-  const {apiCall} = useApi();
-  const [history, setHistory] = useState([]);
-
-  useEffect(() => {
-    const fetchHistory = async () => {
-      if (!isOpen) return;
-      try {
-        const result = await apiCall(`/teams/${teamId}/members/${memberId}/days/${date}/history`, 'GET');
-        setHistory(result);
-      } catch (error) {
-        console.error('Error fetching day history:', error);
-      }
-    };
-    fetchHistory();
-  }, [isOpen, teamId, memberId, date]);
+  const endpoint = `/teams/${teamId}/members/${memberId}/days/${date}/history`;
+  const {history, listRef, handleScroll} = usePaginatedHistory(isOpen, endpoint);
 
   if (!isOpen) return null;
 
@@ -28,7 +15,7 @@ const DayHistoryModal = ({isOpen, onClose, teamId, memberId, date}) => {
       <div className="day-history-modal">
         <div className="close-button" onClick={onClose}>&times;</div>
         <h3>History for {date} ({history.length} {history.length === 1 ? 'item' : 'items'})</h3>
-        <HistoryList history={history} />
+        <HistoryList history={history} ref={listRef} onScroll={handleScroll} />
       </div>
     </Modal>
   );

--- a/frontend/src/components/HistoryList.jsx
+++ b/frontend/src/components/HistoryList.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {format} from 'date-fns';
 
-const HistoryList = ({history, showDate = false}) => (
-  <div className="day-history-list">
+const HistoryList = React.forwardRef(({history, showDate = false, onScroll}, ref) => (
+  <div className="day-history-list" ref={ref} onScroll={onScroll}>
     {history.length === 0 && <p>No history found.</p>}
     {history.map((entry) => {
       const dayTypesEqual = () => {
@@ -77,6 +77,6 @@ const HistoryList = ({history, showDate = false}) => (
       );
     })}
   </div>
-);
+));
 
 export default HistoryList;

--- a/frontend/src/components/MemberHistoryModal.jsx
+++ b/frontend/src/components/MemberHistoryModal.jsx
@@ -1,25 +1,12 @@
-import React, {useEffect, useState} from 'react';
+import React from 'react';
 import Modal from './Modal';
-import {useApi} from '../hooks/useApi';
 import './DayHistoryModal.css';
 import HistoryList from './HistoryList';
+import {usePaginatedHistory} from '../hooks/usePaginatedHistory';
 
 const MemberHistoryModal = ({isOpen, onClose, teamId, memberId, memberName}) => {
-  const {apiCall} = useApi();
-  const [history, setHistory] = useState([]);
-
-  useEffect(() => {
-    const fetchHistory = async () => {
-      if (!isOpen) return;
-      try {
-        const result = await apiCall(`/teams/${teamId}/members/${memberId}/history`, 'GET');
-        setHistory(result);
-      } catch (error) {
-        console.error('Error fetching member history:', error);
-      }
-    };
-    fetchHistory();
-  }, [isOpen, teamId, memberId]);
+  const endpoint = `/teams/${teamId}/members/${memberId}/history`;
+  const {history, listRef, handleScroll} = usePaginatedHistory(isOpen, endpoint);
 
   if (!isOpen) return null;
 
@@ -28,7 +15,12 @@ const MemberHistoryModal = ({isOpen, onClose, teamId, memberId, memberName}) => 
       <div className="day-history-modal">
         <div className="close-button" onClick={onClose}>&times;</div>
         <h3>History for {memberName} ({history.length} {history.length === 1 ? 'item' : 'items'})</h3>
-        <HistoryList history={history} showDate />
+        <HistoryList
+          history={history}
+          showDate
+          ref={listRef}
+          onScroll={handleScroll}
+        />
       </div>
     </Modal>
   );

--- a/frontend/src/hooks/usePaginatedHistory.js
+++ b/frontend/src/hooks/usePaginatedHistory.js
@@ -1,0 +1,49 @@
+import { useState, useEffect, useRef } from 'react';
+import { useApi } from './useApi';
+
+export const usePaginatedHistory = (isActive, endpoint) => {
+  const { apiCall } = useApi();
+  const [history, setHistory] = useState([]);
+  const [hasMore, setHasMore] = useState(true);
+  const [isFetching, setIsFetching] = useState(false);
+  const listRef = useRef(null);
+  const limit = 100;
+
+  const load = async (skip = 0) => {
+    if (isFetching || !hasMore) return;
+    setIsFetching(true);
+    try {
+      const result = await apiCall(`${endpoint}?skip=${skip}&limit=${limit}`, 'GET');
+      if (skip === 0) {
+        setHistory(result);
+      } else {
+        setHistory((prev) => [...prev, ...result]);
+      }
+      if (result.length < limit) {
+        setHasMore(false);
+      }
+    } catch (err) {
+      console.error('Error fetching history:', err);
+    } finally {
+      setIsFetching(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!isActive) return;
+    setHistory([]);
+    setHasMore(true);
+    load(0);
+  }, [isActive, endpoint]);
+
+  const handleScroll = () => {
+    const el = listRef.current;
+    if (!el || isFetching || !hasMore) return;
+    if (el.scrollTop + el.clientHeight >= el.scrollHeight - 5) {
+      load(history.length);
+    }
+  };
+
+  return { history, listRef, handleScroll };
+};
+


### PR DESCRIPTION
## Summary
- extract shared paginated history hook to remove duplicated scrolling logic in day and member modals
- use common helper in backend to paginate day audits for both member and day history endpoints
- unify history pagination tests with parameterized case for day and member endpoints

## Testing
- `pytest backend`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a468f72ad88320a90033bcd053a72d