### PR TITLE
fix: ensure history loads consistently

### DIFF
--- a/frontend/src/hooks/usePaginatedHistory.js
+++ b/frontend/src/hooks/usePaginatedHistory.js
@@ -9,8 +9,8 @@ export const usePaginatedHistory = (isActive, endpoint) => {
   const listRef = useRef(null);
   const limit = 100;
 
-  const load = async (skip = 0) => {
-    if (isFetching || !hasMore) return;
+  const load = async (skip = 0, force = false) => {
+    if (isFetching || (!hasMore && !force)) return;
     setIsFetching(true);
     try {
       const result = await apiCall(`${endpoint}?skip=${skip}&limit=${limit}`, 'GET');
@@ -33,7 +33,7 @@ export const usePaginatedHistory = (isActive, endpoint) => {
     if (!isActive) return;
     setHistory([]);
     setHasMore(true);
-    load(0);
+    load(0, true);
   }, [isActive, endpoint]);
 
   const handleScroll = () => {


### PR DESCRIPTION
## Summary
- prevent history hook from skipping initial load by allowing forced loads

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a4add5655c8320b229de64791c4deb