### PR TITLE
Use constant-time hash comparison for Telegram auth

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -187,7 +187,7 @@ class TelegramAuthData(BaseModel):
         secret_key = hashlib.sha256(TELEGRAM_BOT_TOKEN.encode()).digest()
         calculated_hash = hmac.new(secret_key, data_check_string.encode(), hashlib.sha256).hexdigest()
 
-        if calculated_hash != telegram_hash:
+        if not hmac.compare_digest(calculated_hash, telegram_hash):
             raise ValueError("Data is NOT from Telegram")
 
         return input_values


### PR DESCRIPTION
## Summary
- Use `hmac.compare_digest` to validate Telegram authorization data

## Testing
- `pip install -r backend/requirements.txt`
- `pip install httpx`
- `pytest backend`


------
https://chatgpt.com/codex/tasks/task_e_68a4c8eebc848320a4fb2df44823b33e