### PR TITLE
Generalize export report to absence days

### DIFF
--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -13,7 +13,15 @@ def setup_teams():
     tenant = Tenant(name=f"Tenant{uuid.uuid4()}", identifier=str(uuid.uuid4())).save()
     DayType.init_day_types(tenant)
     vacation = DayType.objects(tenant=tenant, identifier="vacation").first()
-    member1 = TeamMember(name="Alice", country="Sweden", days={"2025-01-01": DayEntry(day_types=[vacation])})
+    comp_leave = DayType.objects(tenant=tenant, identifier="compensatory_leave").first()
+    member1 = TeamMember(
+        name="Alice",
+        country="Sweden",
+        days={
+            "2025-01-01": DayEntry(day_types=[vacation]),
+            "2025-01-02": DayEntry(day_types=[comp_leave]),
+        },
+    )
     team1 = Team(tenant=tenant, name="Team1", team_members=[member1])
     team1.save()
     member2 = TeamMember(name="Bob", country="Sweden", days={"2025-01-01": DayEntry(day_types=[vacation])})
@@ -33,5 +41,16 @@ def test_export_selected_team():
     wb = load_workbook(BytesIO(resp.content))
     ws = wb.active
     rows = list(ws.iter_rows(values_only=True))
+    headers = rows[0]
+    assert "Absence Days" in headers
+    assert "Vacation" in headers
+    assert "Compensatory leave" in headers
+    abs_idx = headers.index("Absence Days")
+    vac_idx = headers.index("Vacation")
+    comp_idx = headers.index("Compensatory leave")
     assert any(r[0] == "Team1" for r in rows[1:])
     assert not any(r[0] == "Team2" for r in rows[1:])
+    team1_row = next(r for r in rows[1:] if r[0] == "Team1")
+    assert team1_row[abs_idx] == 2
+    assert team1_row[vac_idx] == 1
+    assert team1_row[comp_idx] == 1


### PR DESCRIPTION
## Summary
- Show total absence days instead of vacation days in team export report
- Include vacation among other day types and count any absence type
- Add test verifying absence aggregation and inclusion of vacation day type

## Testing
- `pip install -r backend/requirements.txt`
- `pip install httpx`
- `pytest backend`

------
https://chatgpt.com/codex/tasks/task_e_68a9aebf97148320a38d80a243178725