### PR TITLE
feat(frontend): support day type absence flag

### DIFF
--- a/frontend/src/components/settings/DayTypeModal.jsx
+++ b/frontend/src/components/settings/DayTypeModal.jsx
@@ -9,6 +9,7 @@ const DayTypeModal = ({ isOpen, onClose, editingDayType }) => {
         name: '',
         identifier: '',
         color: '',
+        is_absence: false,
     });
     const { apiCall } = useApi();
 
@@ -18,6 +19,7 @@ const DayTypeModal = ({ isOpen, onClose, editingDayType }) => {
                 name: editingDayType.name,
                 identifier: editingDayType.identifier,
                 color: editingDayType.color,
+                is_absence: editingDayType.is_absence,
             });
         }
     }, [editingDayType]);
@@ -38,8 +40,8 @@ const DayTypeModal = ({ isOpen, onClose, editingDayType }) => {
     };
 
     const handleChange = (e) => {
-        const { name, value } = e.target;
-        setDayTypeData({ ...dayTypeData, [name]: value });
+        const { name, type, checked, value } = e.target;
+        setDayTypeData({ ...dayTypeData, [name]: type === 'checkbox' ? checked : value });
     };
 
     if (!isOpen) return null;
@@ -80,6 +82,15 @@ const DayTypeModal = ({ isOpen, onClose, editingDayType }) => {
                             className="color-picker"
                         />
                     </div>
+                    <label>
+                        <input
+                            type="checkbox"
+                            name="is_absence"
+                            checked={dayTypeData.is_absence}
+                            onChange={handleChange}
+                        />
+                        Absence
+                    </label>
                     <div className="button-container">
                         <button type="submit">{editingDayType ? 'Update' : 'Add'} Day Type</button>
                         <button type="button" onClick={onClose}>Close</button>

--- a/frontend/src/components/settings/DayTypes.jsx
+++ b/frontend/src/components/settings/DayTypes.jsx
@@ -60,6 +60,7 @@ const DayTypes = () => {
                     <th>Name</th>
                     <th>Identifier</th>
                     <th>Color</th>
+                    <th>Absence</th>
                     <th>Actions</th>
                 </tr>
                 </thead>
@@ -72,6 +73,7 @@ const DayTypes = () => {
                               <div className="colorCircle" style={{backgroundColor: dayType.color}}></div>
                               {dayType.color}
                           </td>
+                          <td>{dayType.is_absence ? 'Yes' : 'No'}</td>
                           <td>
                               <FontAwesomeIcon icon={faEdit} onClick={() => handleEditDayTypeClick(dayType)}
                                                className="firstActionIcon"


### PR DESCRIPTION
## Summary
- allow marking day types as absence in settings modal
- show absence state in day types settings table

## Testing
- `npm ci`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a9b158cc608320b87e76b167536fa8