### PR TITLE
Rename vacation export endpoint to absences

### DIFF
--- a/backend/routers/teams.py
+++ b/backend/routers/teams.py
@@ -478,11 +478,11 @@ def auto_adjust_column_width(ws):
         ws.column_dimensions[get_column_letter(column)].width = max_length
 
 
-@router.get("/export-vacations")
-async def export_vacation_report(current_user: Annotated[User, Depends(get_current_active_user_check_tenant)],
-                                 tenant: Annotated[Tenant, Depends(get_tenant)],
-                                 start_date: datetime.date = Query(...), end_date: datetime.date = Query(...),
-                                 team_ids: List[str] | None = Query(None)):
+@router.get("/export-absences")
+async def export_absence_report(current_user: Annotated[User, Depends(get_current_active_user_check_tenant)],
+                                tenant: Annotated[Tenant, Depends(get_tenant)],
+                                start_date: datetime.date = Query(...), end_date: datetime.date = Query(...),
+                                team_ids: List[str] | None = Query(None)):
     wb = Workbook()
     ws = wb.active
     ws.title = "Day Type Report"
@@ -505,9 +505,13 @@ async def export_vacation_report(current_user: Annotated[User, Depends(get_curre
     wb.save(b_io)
     b_io.seek(0)
 
-    return StreamingResponse(b_io, media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                             headers={
-                                 "Content-Disposition": f"attachment; filename=vacations_{start_date}_{end_date}.xlsx"})
+    return StreamingResponse(
+        b_io,
+        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        headers={
+            "Content-Disposition": f"attachment; filename=absences_{start_date}_{end_date}.xlsx"
+        },
+    )
 
 
 def build_team_calendar(team: Team) -> Calendar:

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -34,8 +34,14 @@ def test_export_selected_team():
     team1, team2 = setup_teams()
     app.dependency_overrides[get_current_active_user_check_tenant] = lambda: User(tenants=[team1.tenant])
     app.dependency_overrides[get_tenant] = lambda: team1.tenant
-    resp = client.get(f"/teams/export-vacations?start_date=2025-01-01&end_date=2025-12-31&team_ids={team1.id}")
+    resp = client.get(
+        f"/teams/export-absences?start_date=2025-01-01&end_date=2025-12-31&team_ids={team1.id}"
+    )
     assert resp.status_code == 200
+    assert (
+        resp.headers["Content-Disposition"]
+        == "attachment; filename=absences_2025-01-01_2025-12-31.xlsx"
+    )
     app.dependency_overrides = {}
     from io import BytesIO
     wb = load_workbook(BytesIO(resp.content))

--- a/frontend/src/components/MainComponent.jsx
+++ b/frontend/src/components/MainComponent.jsx
@@ -71,14 +71,14 @@ const MainComponent = () => {
     const handleGenerateReport = async (startDate, endDate, teamIds) => {
         setShowReportModal(false);
         const teamsQuery = teamIds && teamIds.length > 0 ? `&${teamIds.map(id => `team_ids=${id}`).join('&')}` : '';
-        const reportUrl = `/teams/export-vacations?start_date=${startDate}&end_date=${endDate}${teamsQuery}`;
+        const reportUrl = `/teams/export-absences?start_date=${startDate}&end_date=${endDate}${teamsQuery}`;
 
         try {
             const blob = await apiCall(reportUrl, 'GET', null, true); // Set isBlob to true
             const url = window.URL.createObjectURL(blob);
             const a = document.createElement('a');
             a.href = url;
-            a.download = `vacations_${startDate}_${endDate}.xlsx`; // Set the desired file name
+            a.download = `absences_${startDate}_${endDate}.xlsx`; // Set the desired file name
             document.body.appendChild(a);
             a.click();
             a.remove();


### PR DESCRIPTION
## Summary
- rename teams export-vacations endpoint and function to export-absences
- adjust frontend report generation to use new absences endpoint and filename
- update export test for new absences route and file naming

## Testing
- `pytest backend`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a9b9c9e77c832089c068eb4a0d31f0