### PR TITLE
Restrict absence flag on system day types

### DIFF
--- a/backend/routers/daytypes.py
+++ b/backend/routers/daytypes.py
@@ -67,6 +67,10 @@ async def update_day_type(day_type_id: str, day_type_dto: DayTypeWriteDTO,
     if day_type.identifier in DayType.SYSTEM_DAY_TYPE_IDENTIFIERS and day_type.identifier != day_type_dto.identifier:
         raise HTTPException(status_code=400, detail="Can't change the identifier for the system DayType")
 
+    if (day_type.identifier in DayType.SYSTEM_DAY_TYPE_IDENTIFIERS and
+            day_type.is_absence != day_type_dto.is_absence):
+        raise HTTPException(status_code=400, detail="Can't change the is_absence flag for the system DayType")
+
     day_type.name = day_type_dto.name
     day_type.identifier = day_type_dto.identifier
     day_type.color = day_type_dto.color

--- a/backend/tests/routers/test_daytypes.py
+++ b/backend/tests/routers/test_daytypes.py
@@ -1,0 +1,50 @@
+import os
+import uuid
+import pytest
+
+os.environ.setdefault("MONGO_MOCK", "1")
+os.environ.setdefault("AUTHENTICATION_SECRET_KEY", "test_secret")
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.model import DayType, Tenant, User, AuthDetails
+from backend.dependencies import get_current_active_user_check_tenant, get_tenant
+
+client = TestClient(app)
+
+
+def setup_day_type(identifier: str):
+    tenant = Tenant(name=f"Test Tenant {uuid.uuid4()}", identifier=str(uuid.uuid4())).save()
+    DayType.init_day_types(tenant)
+    day_type = DayType.objects(tenant=tenant, identifier=identifier).first()
+    user = User(
+        name="Test User",
+        email=f"{uuid.uuid4()}@example.com",
+        tenants=[tenant],
+        auth_details=AuthDetails(username=str(uuid.uuid4())),
+    ).save()
+    return tenant, user, day_type
+
+
+@pytest.mark.parametrize("identifier", DayType.SYSTEM_DAY_TYPE_IDENTIFIERS)
+def test_cannot_toggle_is_absence_for_system_day_types(identifier):
+    tenant, user, day_type = setup_day_type(identifier)
+    app.dependency_overrides[get_current_active_user_check_tenant] = lambda: user
+    app.dependency_overrides[get_tenant] = lambda: tenant
+
+    payload = {
+        "name": day_type.name,
+        "identifier": day_type.identifier,
+        "color": day_type.color,
+        "is_absence": not day_type.is_absence,
+    }
+
+    response = client.put(
+        f"/daytypes/{day_type.id}",
+        json=payload,
+        headers={"Tenant-ID": tenant.identifier},
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Can't change the is_absence flag for the system DayType"
+    app.dependency_overrides = {}


### PR DESCRIPTION
## Summary
- block updates to the absence flag for built-in day types
- test that API rejects changing system day type absence status

## Testing
- `pytest backend`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a9ba3a7ba883208388e5f895a966a7