### PR TITLE
Ensure tenant context is cleared after request errors

### DIFF
--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -89,8 +89,10 @@ class TenantMiddleware(BaseHTTPMiddleware):
         tenant_identifier = request.headers.get("Tenant-ID")
         tenant = Tenant.objects(identifier=tenant_identifier).first()
         token = tenant_var.set(tenant)
-        response = await call_next(request)
-        tenant_var.reset(token)
+        try:
+            response = await call_next(request)
+        finally:
+            tenant_var.reset(token)
         return response
 
 

--- a/backend/tests/test_tenant_middleware.py
+++ b/backend/tests/test_tenant_middleware.py
@@ -1,0 +1,34 @@
+import asyncio
+import pytest
+from starlette.requests import Request
+
+from backend.dependencies import TenantMiddleware, tenant_var
+from backend.model import Tenant
+
+
+def _build_request(tenant_id: str) -> Request:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": [(b"tenant-id", tenant_id.encode())],
+    }
+    return Request(scope)
+
+
+def test_tenant_middleware_resets_context_on_exception():
+    async def run_test():
+        Tenant(name="Test", identifier="tenant1").save()
+        middleware = TenantMiddleware(lambda req: None)
+        request = _build_request("tenant1")
+        token = tenant_var.set("original")
+        try:
+            async def call_next(req):
+                raise RuntimeError("boom")
+            with pytest.raises(RuntimeError):
+                await middleware.dispatch(request, call_next)
+            assert tenant_var.get() == "original"
+        finally:
+            tenant_var.reset(token)
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- safeguard tenant context variable against leakage when requests raise exceptions
- add regression test for TenantMiddleware cleanup

## Testing
- `pytest backend`


------
https://chatgpt.com/codex/tasks/task_e_68a9be5f342483208f52a89c9a4d8707