### PR TITLE
feat: store google auth details

### DIFF
--- a/backend/model.py
+++ b/backend/model.py
@@ -152,6 +152,10 @@ class AuthDetails(EmbeddedDocument):
     # Stores various authentication details
     telegram_id = LongField(unique=True, sparse=True)
     telegram_username = StringField(unique=True, required=False, sparse=True)
+    # Fields for Google authentication
+    google_id = StringField(unique=True, required=False, sparse=True)
+    google_email = EmailField(unique=True, required=False, sparse=True)
+    google_refresh_token = StringField(required=False)
     # Fields for username/password authentication
     username = StringField(unique=True, required=True, sparse=True)
     hashed_password = StringField(required=False)
@@ -178,7 +182,9 @@ class User(Document):
             "auth_details.telegram_username",
             "auth_details.username",
             "tenants",
-            "auth_details.api_key"
+            "auth_details.api_key",
+            "auth_details.google_id",
+            "auth_details.google_email"
         ],
         "index_background": True
     }
@@ -190,6 +196,11 @@ class User(Document):
     @classmethod
     def get_by_username(cls, username: str):
         user = cls.objects(auth_details__username=username).first()
+        return user
+
+    @classmethod
+    def get_by_google_id(cls, google_id: str):
+        user = cls.objects(auth_details__google_id=google_id).first()
         return user
 
     def hash_password(self, plain_password):

--- a/backend/tests/test_google_auth_details.py
+++ b/backend/tests/test_google_auth_details.py
@@ -1,0 +1,23 @@
+import uuid
+
+from backend.model import Tenant, User, AuthDetails
+
+
+def test_get_by_google_id():
+    tenant = Tenant(name=str(uuid.uuid4()), identifier=str(uuid.uuid4())).save()
+    google_id = str(uuid.uuid4())
+    user = User(
+        tenants=[tenant],
+        name="Google User",
+        email=f"{uuid.uuid4()}@example.com",
+        auth_details=AuthDetails(
+            username=str(uuid.uuid4()),
+            google_id=google_id,
+            google_email="user@example.com",
+            google_refresh_token="refresh-token",
+        ),
+    ).save()
+
+    fetched = User.get_by_google_id(google_id)
+    assert fetched is not None
+    assert fetched.id == user.id


### PR DESCRIPTION
## Summary
- add Google authentication fields to AuthDetails
- allow lookup by Google account
- test storing and retrieving Google auth details

## Testing
- `pip install -r requirements.txt`
- `pip install httpx`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9f5b70bd48320b87556ffd6c37df6