### PR TITLE
fix: guard google login when client id absent

### DIFF
--- a/frontend/src/components/settings/UserManagement.jsx
+++ b/frontend/src/components/settings/UserManagement.jsx
@@ -104,32 +104,44 @@ const UserManagement = () => {
     setShowApiKeyModal(true);
   };
 
-  const googleConnect = useGoogleLogin({
-    scope: 'openid email profile',
-    onSuccess: async (tokenResponse) => {
-      try {
-        const idToken = tokenResponse.id_token;
-        if (!idToken) {
-          toast.error('No ID token received from Google');
-          return;
-        }
-        await apiCall('/google-connect', 'POST', {token: idToken});
-        toast.success('Google account connected');
-        fetchUsers();
-      } catch (error) {
-        console.error('Error connecting Google account:', error);
-        if (error.data && error.data.detail) {
-          toast.error(error.data.detail);
-        } else {
-          toast.error('Error connecting Google account');
-        }
+  const handleGoogleConnect = async (tokenResponse) => {
+    try {
+      const idToken = tokenResponse.id_token;
+      if (!idToken) {
+        toast.error('No ID token received from Google');
+        return;
       }
-    },
-    onError: (error) => {
-      console.error('Google login failed', error);
-      toast.error('Google login failed');
+      await apiCall('/google-connect', 'POST', {token: idToken});
+      toast.success('Google account connected');
+      fetchUsers();
+    } catch (error) {
+      console.error('Error connecting Google account:', error);
+      if (error.data && error.data.detail) {
+        toast.error(error.data.detail);
+      } else {
+        toast.error('Error connecting Google account');
+      }
     }
-  });
+  };
+
+  const GoogleConnectButton = () => {
+    const googleConnect = useGoogleLogin({
+      scope: 'openid email profile',
+      onSuccess: handleGoogleConnect,
+      onError: (error) => {
+        console.error('Google login failed', error);
+        toast.error('Google login failed');
+      }
+    });
+    return (
+      <FontAwesomeIcon icon={faGoogle}
+                       onClick={() => googleConnect()}
+                       className="actionIcon"
+                       title="Connect Google account"
+                       aria-label="Connect Google account"
+      />
+    );
+  };
 
   const handleResetMfa = async (userId, userName) => {
     const isConfirmed = window.confirm(`Reset MFA for ${userName}?`);
@@ -208,12 +220,7 @@ const UserManagement = () => {
                                    aria-label="Show API key"
                   />
                   {googleClientId && !u.auth_details?.google_id && (
-                    <FontAwesomeIcon icon={faGoogle}
-                                     onClick={() => googleConnect()}
-                                     className="actionIcon"
-                                     title="Connect Google account"
-                                     aria-label="Connect Google account"
-                    />
+                    <GoogleConnectButton/>
                   )}
                 </>
               )}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -15,6 +15,13 @@ const AppProviders = () => {
   if (!configLoaded) {
     return null;
   }
+  if (!googleClientId) {
+    return (
+      <AuthProvider>
+        <App/>
+      </AuthProvider>
+    );
+  }
   return (
     <GoogleOAuthProvider clientId={googleClientId}>
       <AuthProvider>


### PR DESCRIPTION
## Summary
- Avoid initializing Google OAuth when client ID is not configured
- Mount Google login hook only when client ID is available to prevent missing parameter error

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abebc36d2c8320be44e8088e417c6c