### PR TITLE
Allow cross-origin popups for Google login

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin-allow-popups" />
     <meta
       name="description"
       content="Vacal - VAcation CALendar management tool"


### PR DESCRIPTION
## Summary
- allow popups like Google sign-in to close properly by setting COOP to same-origin-allow-popups

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ac7453f3e883209e886c1daf4b5557