### PR TITLE
feat: add frontend Google login

### DIFF
--- a/frontend/src/components/auth/GoogleLogin.jsx
+++ b/frontend/src/components/auth/GoogleLogin.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import {useAuth} from "../../contexts/AuthContext";
+import useGoogleAuth from "../../hooks/useGoogleAuth";
+import './SocialLogin.css';
+
+const GoogleLogin = () => {
+  const {handleGoogleLogin} = useAuth();
+  const googleLogin = useGoogleAuth(async (tokenResponse) => {
+    await handleGoogleLogin(tokenResponse);
+  });
+
+  return (
+    <div className="socialLoginContainer">
+      <h3>Log in to your existing Vacal account with Google</h3>
+      <button className="buttonStyle" onClick={() => googleLogin()}>Log in with Google</button>
+    </div>
+  );
+};
+
+export default GoogleLogin;

--- a/frontend/src/components/auth/Login.jsx
+++ b/frontend/src/components/auth/Login.jsx
@@ -5,12 +5,13 @@ import {useAuth} from "../../contexts/AuthContext";
 import {useNavigate} from "react-router-dom";
 import {toast} from 'react-toastify';
 import TelegramLogin from "./TelegramLogin";
+import GoogleLogin from "./GoogleLogin";
 import {useConfig} from "../../contexts/ConfigContext";
 
 const Login = () => {
   const {handleLogin} = useAuth();
   const navigate = useNavigate();
-  const {isMultitenancyEnabled, isTelegramEnabled, telegramBotUsername, userInitiated} = useConfig();
+  const {isMultitenancyEnabled, isTelegramEnabled, telegramBotUsername, userInitiated, googleClientId} = useConfig();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [otp, setOtp] = useState('');
@@ -111,6 +112,7 @@ const Login = () => {
             Forgot password?
           </p>
         </form>
+        {googleClientId && <GoogleLogin/>}
         {isTelegramEnabled && <TelegramLogin telegramBotUsername={telegramBotUsername}/>}
       </div>
     </div>

--- a/frontend/src/components/auth/SocialLogin.css
+++ b/frontend/src/components/auth/SocialLogin.css
@@ -1,4 +1,4 @@
-.telegramLoginContainer {
+.socialLoginContainer {
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/frontend/src/components/auth/TelegramLogin.jsx
+++ b/frontend/src/components/auth/TelegramLogin.jsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useRef} from 'react';
 import {useAuth} from "../../contexts/AuthContext";
 import {useNavigate} from "react-router-dom";
-import './TelegramLogin.css';
+import './SocialLogin.css';
 
 
 const TelegramLogin = ({telegramBotUsername}) => {
@@ -36,7 +36,7 @@ const TelegramLogin = ({telegramBotUsername}) => {
   }, []);
 
   return (
-    <div className="telegramLoginContainer">
+    <div className="socialLoginContainer">
       <h3>Log in to your existing Vacal account with Telegram</h3>
       <div ref={telegramWidgetRef}></div>
     </div>

--- a/frontend/src/components/settings/UserManagement.jsx
+++ b/frontend/src/components/settings/UserManagement.jsx
@@ -11,8 +11,8 @@ import ApiKeyModal from './ApiKeyModal';
 import InviteUserModal from './InviteUserModal';
 import InviteManagement from './InviteManagement';
 import {useLocation, useNavigate} from "react-router-dom";
-import {useGoogleLogin} from '@react-oauth/google';
 import {faGoogle} from '@fortawesome/free-brands-svg-icons';
+import useGoogleAuth from '../../hooks/useGoogleAuth';
 
 const UserManagement = () => {
   const location = useLocation();
@@ -125,14 +125,7 @@ const UserManagement = () => {
   };
 
   const GoogleConnectButton = () => {
-    const googleConnect = useGoogleLogin({
-      scope: 'openid email profile',
-      onSuccess: handleGoogleConnect,
-      onError: (error) => {
-        console.error('Google login failed', error);
-        toast.error('Google login failed');
-      }
-    });
+    const googleConnect = useGoogleAuth(handleGoogleConnect);
     return (
       <FontAwesomeIcon icon={faGoogle}
                        onClick={() => googleConnect()}

--- a/frontend/src/hooks/useGoogleAuth.js
+++ b/frontend/src/hooks/useGoogleAuth.js
@@ -1,0 +1,15 @@
+import {useGoogleLogin} from '@react-oauth/google';
+import {toast} from 'react-toastify';
+
+const useGoogleAuth = (onSuccess) => {
+  return useGoogleLogin({
+    scope: 'openid email profile',
+    onSuccess,
+    onError: (error) => {
+      console.error('Google login failed', error);
+      toast.error('Google login failed');
+    }
+  });
+};
+
+export default useGoogleAuth;


### PR DESCRIPTION
## Summary
- add Google login button on login page when Google auth configured
- extract reusable Google OAuth hook and use it for login and account linking
- handle Google login in auth context

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68ac404aace88320bbe3ede2e4d853bc