### PR TITLE
Add Google account disconnect and show linked email

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -148,6 +148,13 @@ def link_google_account(user: User, google_id: str, email: str | None):
     user.save()
 
 
+def unlink_google_account(user: User):
+    user.auth_details.google_id = None
+    user.auth_details.google_email = None
+    user.auth_details.google_refresh_token = None
+    user.save()
+
+
 class OAuth2PasswordRequestFormMFA(OAuth2PasswordRequestForm):
     def __init__(self, grant_type: str = Form(None, regex="password"), username: str = Form(...),
                  password: str = Form(...), scope: str = Form(""), client_id: str = Form(None),
@@ -284,3 +291,11 @@ async def google_connect(
 
     link_google_account(current_user, google_id, email)
     return {"detail": "Google account linked successfully"}
+
+
+@app.delete("/google-connect")
+async def google_disconnect(
+    current_user: Annotated[User, Depends(get_current_active_user)],
+):
+    unlink_google_account(current_user)
+    return {"detail": "Google account disconnected successfully"}

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -7,7 +7,7 @@ from functools import lru_cache
 from typing import Annotated, List
 
 from fastapi import APIRouter, HTTPException, Depends, BackgroundTasks
-from pydantic import field_validator, BaseModel, Field, computed_field
+from pydantic import field_validator, BaseModel, Field, computed_field, field_serializer
 from starlette import status
 
 from ..dependencies import get_current_active_user, get_tenant, mongo_to_pydantic, get_current_active_user_check_tenant, \
@@ -41,6 +41,16 @@ class AuthDetailsDTO(BaseModel):
     telegram_username: str | None = None
     username: str
     api_key: str | None = None
+    google_id: str | None = None
+    google_email: str | None = None
+
+    @field_serializer('google_email')
+    def mask_google_email(self, email: str | None):
+        if not email or '@' not in email:
+            return email
+        local, domain = email.split('@', 1)
+        masked_local = local[0] + '*' * max(len(local) - 2, 1) + local[-1]
+        return f"{masked_local}@{domain}"
 
 
 class UserWithoutTenantsDTO(BaseModel):

--- a/backend/tests/test_google_disconnect.py
+++ b/backend/tests/test_google_disconnect.py
@@ -1,0 +1,26 @@
+import uuid
+from fastapi.testclient import TestClient
+
+from backend.main import app, get_current_active_user
+from backend.model import Tenant, User, AuthDetails
+
+client = TestClient(app)
+
+
+def test_google_disconnect_removes_auth_details():
+    tenant = Tenant(name=str(uuid.uuid4()), identifier=str(uuid.uuid4())).save()
+    email = f"{uuid.uuid4()}@example.com"
+    user = User(
+        tenants=[tenant],
+        name="Google User",
+        auth_details=AuthDetails(username=str(uuid.uuid4()), google_id=str(uuid.uuid4()), google_email=email),
+    ).save()
+
+    app.dependency_overrides[get_current_active_user] = lambda: user
+
+    response = client.delete("/google-connect")
+    app.dependency_overrides.clear()
+    assert response.status_code == 200
+    user.reload()
+    assert user.auth_details.google_id is None
+    assert user.auth_details.google_email is None

--- a/backend/tests/test_google_email_masking.py
+++ b/backend/tests/test_google_email_masking.py
@@ -1,0 +1,30 @@
+import uuid
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.dependencies import get_current_active_user_check_tenant, get_tenant
+from backend.model import Tenant, User, AuthDetails
+
+client = TestClient(app)
+
+
+def test_google_email_is_masked_in_users_endpoint():
+    tenant = Tenant(name=str(uuid.uuid4()), identifier=str(uuid.uuid4())).save()
+    email = f"{uuid.uuid4()}@example.com"
+    user = User(
+        tenants=[tenant],
+        name="Google User",
+        auth_details=AuthDetails(username=str(uuid.uuid4()), google_id=str(uuid.uuid4()), google_email=email),
+    ).save()
+
+    app.dependency_overrides[get_current_active_user_check_tenant] = lambda: user
+    app.dependency_overrides[get_tenant] = lambda: tenant
+
+    response = client.get("/users")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    data = response.json()
+    local, domain = email.split('@', 1)
+    expected = f"{local[0]}{'*' * max(len(local) - 2, 1)}{local[-1]}@{domain}"
+    assert data[0]["auth_details"]["google_email"] == expected

--- a/frontend/src/components/settings/UserManagement.jsx
+++ b/frontend/src/components/settings/UserManagement.jsx
@@ -2,7 +2,7 @@ import React, {useEffect, useState} from 'react';
 import {useApi} from '../../hooks/useApi';
 import UserModal from './UserModal';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
-import {faEdit, faKey, faTrashAlt, faSyncAlt, faLock} from '@fortawesome/free-solid-svg-icons';
+import {faEdit, faKey, faTrashAlt, faSyncAlt, faLock, faUnlink} from '@fortawesome/free-solid-svg-icons';
 import {useAuth} from "../../contexts/AuthContext";
 import {useConfig} from "../../contexts/ConfigContext";
 import {toast} from 'react-toastify';
@@ -124,6 +124,21 @@ const UserManagement = () => {
     }
   };
 
+  const handleGoogleDisconnect = async () => {
+    try {
+      await apiCall('/google-connect', 'DELETE');
+      toast.success('Google account disconnected');
+      fetchUsers();
+    } catch (error) {
+      console.error('Error disconnecting Google account:', error);
+      if (error.data && error.data.detail) {
+        toast.error(error.data.detail);
+      } else {
+        toast.error('Error disconnecting Google account');
+      }
+    }
+  };
+
   const GoogleConnectButton = () => {
     const googleConnect = useGoogleAuth(handleGoogleConnect);
     return (
@@ -132,6 +147,17 @@ const UserManagement = () => {
                        className="actionIcon"
                        title="Connect Google account"
                        aria-label="Connect Google account"
+      />
+    );
+  };
+
+  const GoogleDisconnectButton = () => {
+    return (
+      <FontAwesomeIcon icon={faUnlink}
+                       onClick={handleGoogleDisconnect}
+                       className="actionIcon"
+                       title="Disconnect Google account"
+                       aria-label="Disconnect Google account"
       />
     );
   };
@@ -169,6 +195,7 @@ const UserManagement = () => {
           <th>Email</th>
           <th>Username</th>
           <th>Telegram Username</th>
+          <th>Google Email</th>
           <th>Status</th>
           <th>Actions</th>
         </tr>
@@ -180,6 +207,7 @@ const UserManagement = () => {
             <td>{u.email}</td>
             <td>{u.username}</td>
             <td>{u.telegram_username}</td>
+            <td>{u.auth_details?.google_email ?? ''}</td>
             <td>{u.disabled ? 'Disabled' : 'Active'}</td>
             <td>
               <FontAwesomeIcon icon={faEdit}
@@ -214,6 +242,9 @@ const UserManagement = () => {
                   />
                   {googleClientId && !u.auth_details?.google_id && (
                     <GoogleConnectButton/>
+                  )}
+                  {googleClientId && u.auth_details?.google_id && (
+                    <GoogleDisconnectButton/>
                   )}
                 </>
               )}


### PR DESCRIPTION
## Summary
- allow users to unlink their Google account via new `/google-connect` DELETE route
- expose Google auth details and display masked Google email in user management
- toggle connect button to disconnect when Google account is linked
- mask linked Google email on the backend

## Testing
- `pip install -r backend/requirements.txt`
- `pip install httpx`
- `pytest backend`
- `npm install`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68acb4adbc4c832096d7d07b1a85eafb