### PR TITLE
Redirect after Google login and centralize success handling

### DIFF
--- a/frontend/src/components/auth/GoogleLogin.jsx
+++ b/frontend/src/components/auth/GoogleLogin.jsx
@@ -1,12 +1,17 @@
 import React from 'react';
 import {useAuth} from "../../contexts/AuthContext";
+import {useNavigate} from "react-router-dom";
 import useGoogleAuth from "../../hooks/useGoogleAuth";
 import './SocialLogin.css';
 
 const GoogleLogin = () => {
   const {handleGoogleLogin} = useAuth();
+  const navigate = useNavigate();
   const googleLogin = useGoogleAuth(async (tokenResponse) => {
-    await handleGoogleLogin(tokenResponse);
+    const result = await handleGoogleLogin(tokenResponse);
+    if (result?.success) {
+      navigate('/');
+    }
   });
 
   return (

--- a/frontend/src/components/auth/TelegramLogin.jsx
+++ b/frontend/src/components/auth/TelegramLogin.jsx
@@ -12,8 +12,10 @@ const TelegramLogin = ({telegramBotUsername}) => {
   useEffect(() => {
     // Define the onTelegramAuth function
     window.onTelegramAuth = async (user) => {
-      await handleTelegramLogin(user);
-      navigate('/');
+      const result = await handleTelegramLogin(user);
+      if (result?.success) {
+        navigate('/');
+      }
     };
 
     const script = document.createElement('script');


### PR DESCRIPTION
## Summary
- centralize auth token handling in AuthContext
- redirect to home after successful Google or Telegram login

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68acbf2a46d4832087388f94ec2fc899