### PR TITLE
refactor: consolidate Google auth token handling

### DIFF
--- a/frontend/src/components/auth/GoogleLogin.jsx
+++ b/frontend/src/components/auth/GoogleLogin.jsx
@@ -10,12 +10,7 @@ const GoogleLogin = () => {
   const navigate = useNavigate();
 
   const onSuccess = async (credentialResponse) => {
-    const idToken = credentialResponse.credential;
-    if (!idToken) {
-      toast.error('No ID token received from Google');
-      return;
-    }
-    const result = await handleGoogleLogin({id_token: idToken});
+    const result = await handleGoogleLogin(credentialResponse);
     if (result?.success) {
       navigate('/');
     }

--- a/frontend/src/components/settings/UserManagement.jsx
+++ b/frontend/src/components/settings/UserManagement.jsx
@@ -13,6 +13,7 @@ import InviteManagement from './InviteManagement';
 import {useLocation, useNavigate} from "react-router-dom";
 import {faGoogle} from '@fortawesome/free-brands-svg-icons';
 import useGoogleAuth from '../../hooks/useGoogleAuth';
+import {extractGoogleIdToken} from '../../utils/google';
 
 const UserManagement = () => {
   const location = useLocation();
@@ -106,9 +107,8 @@ const UserManagement = () => {
 
   const handleGoogleConnect = async (tokenResponse) => {
     try {
-      const idToken = tokenResponse.id_token;
+      const idToken = extractGoogleIdToken(tokenResponse);
       if (!idToken) {
-        toast.error('No ID token received from Google');
         return;
       }
       await apiCall('/google-connect', 'POST', {token: idToken});

--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -1,5 +1,6 @@
 import React, {createContext, useContext, useEffect} from 'react';
 import {toast} from 'react-toastify';
+import {extractGoogleIdToken} from '../utils/google';
 import {useLocalStorage} from '../hooks/useLocalStorage';
 
 export const AuthContext = createContext();
@@ -107,9 +108,8 @@ export const AuthProvider = ({children}) => {
 
     const handleGoogleLogin = async (tokenResponse) => {
         try {
-            const idToken = tokenResponse.id_token;
+            const idToken = extractGoogleIdToken(tokenResponse);
             if (!idToken) {
-                toast.error('No ID token received from Google');
                 return;
             }
             const response = await fetch(`${process.env.REACT_APP_API_URL}/google-login`, {

--- a/frontend/src/hooks/useGoogleAuth.js
+++ b/frontend/src/hooks/useGoogleAuth.js
@@ -1,6 +1,7 @@
 import {useCallback} from 'react';
 import {useGoogleOAuth} from '@react-oauth/google';
 import {toast} from 'react-toastify';
+import {extractGoogleIdToken} from '../utils/google';
 
 // Custom hook that triggers Google Identity Services and returns an ID token.
 // On success it calls the supplied callback with an object containing `id_token`.
@@ -17,9 +18,8 @@ const useGoogleAuth = (onSuccess) => {
       client_id: clientId,
       ux_mode: 'popup',
       callback: (response) => {
-        const idToken = response.credential;
+        const idToken = extractGoogleIdToken(response);
         if (!idToken) {
-          toast.error('No ID token received from Google');
           return;
         }
         onSuccess({id_token: idToken});

--- a/frontend/src/utils/google.js
+++ b/frontend/src/utils/google.js
@@ -1,0 +1,10 @@
+import {toast} from 'react-toastify';
+
+export const extractGoogleIdToken = (response) => {
+  const idToken = response?.id_token ?? response?.credential;
+  if (!idToken) {
+    toast.error('No ID token received from Google');
+    return null;
+  }
+  return idToken;
+};


### PR DESCRIPTION
## Summary
- centralize Google ID token extraction
- reuse helper across auth context, hook, and components

## Testing
- `cd frontend && npm test -- --watch=false`

------
https://chatgpt.com/codex/tasks/task_e_68ae0fdc42bc8320be26e7e742acd6a0