### PR TITLE
Support Telegram account linking and unlinking

### DIFF
--- a/backend/model.py
+++ b/backend/model.py
@@ -203,6 +203,11 @@ class User(Document):
         user = cls.objects(auth_details__google_id=google_id).first()
         return user
 
+    @classmethod
+    def get_by_telegram_id(cls, telegram_id: int):
+        user = cls.objects(auth_details__telegram_id=telegram_id).first()
+        return user
+
     def hash_password(self, plain_password):
         self.auth_details.hashed_password = pwd_context.hash(plain_password)
 

--- a/backend/tests/test_telegram_connect.py
+++ b/backend/tests/test_telegram_connect.py
@@ -1,0 +1,75 @@
+import time
+import hashlib
+import hmac
+import uuid
+
+from fastapi.testclient import TestClient
+
+from backend.main import app, TELEGRAM_BOT_TOKEN, get_current_active_user
+from backend.model import Tenant, User, AuthDetails
+
+client = TestClient(app)
+
+
+def _generate_payload(username: str, user_id: int):
+    auth_date = int(time.time())
+    data_check_arr = [
+        f"auth_date={auth_date}",
+        f"id={user_id}",
+        f"username={username}",
+    ]
+    data_check_arr.sort()
+    data_check_string = "\n".join(data_check_arr)
+    secret_key = hashlib.sha256(TELEGRAM_BOT_TOKEN.encode()).digest()
+    calculated_hash = hmac.new(secret_key, data_check_string.encode(), hashlib.sha256).hexdigest()
+    return {
+        "hash": calculated_hash,
+        "id": user_id,
+        "auth_date": auth_date,
+        "username": username,
+    }
+
+
+def test_telegram_connect_links_current_user():
+    tenant = Tenant(name=str(uuid.uuid4()), identifier=str(uuid.uuid4())).save()
+    user = User(
+        tenants=[tenant],
+        name="Telegram User",
+        auth_details=AuthDetails(username="existing"),
+    ).save()
+
+    payload = _generate_payload("telegramuser", user_id=111)
+
+    app.dependency_overrides[get_current_active_user] = lambda: user
+    response = client.post("/telegram-connect", json=payload)
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    user.reload()
+    assert user.auth_details.telegram_id == payload["id"]
+    assert user.auth_details.telegram_username == payload["username"]
+
+
+def test_telegram_connect_fails_if_telegram_id_used():
+    tenant = Tenant(name=str(uuid.uuid4()), identifier=str(uuid.uuid4())).save()
+    existing_user = User(
+        tenants=[tenant],
+        name="Other User",
+        auth_details=AuthDetails(username="other", telegram_id=222, telegram_username="existinguser"),
+    ).save()
+    current_user = User(
+        tenants=[tenant],
+        name="Current User",
+        auth_details=AuthDetails(username="current"),
+    ).save()
+
+    payload = _generate_payload("existinguser", user_id=222)
+
+    app.dependency_overrides[get_current_active_user] = lambda: current_user
+    response = client.post("/telegram-connect", json=payload)
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 400
+    current_user.reload()
+    assert current_user.auth_details.telegram_id is None
+    assert current_user.auth_details.telegram_username is None

--- a/backend/tests/test_telegram_disconnect.py
+++ b/backend/tests/test_telegram_disconnect.py
@@ -1,0 +1,26 @@
+import uuid
+from fastapi.testclient import TestClient
+
+from backend.main import app, get_current_active_user
+from backend.model import Tenant, User, AuthDetails
+
+client = TestClient(app)
+
+
+def test_telegram_disconnect_removes_auth_details():
+    tenant = Tenant(name=str(uuid.uuid4()), identifier=str(uuid.uuid4())).save()
+    user = User(
+        tenants=[tenant],
+        name="Telegram User",
+        auth_details=AuthDetails(username=str(uuid.uuid4()), telegram_id=333, telegram_username="user"),
+    ).save()
+
+    app.dependency_overrides[get_current_active_user] = lambda: user
+
+    response = client.delete("/telegram-connect")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    user.reload()
+    assert user.auth_details.telegram_id is None
+    assert user.auth_details.telegram_username is None


### PR DESCRIPTION
## Summary
- add reusable helpers for updating authentication details
- enable linking and unlinking Telegram accounts via new endpoints
- test Telegram linking and unlinking flows

## Testing
- `pip install -r backend/requirements.txt`
- `pip install httpx`
- `pytest backend`

------
https://chatgpt.com/codex/tasks/task_e_68b078a150708320b38f5bcd5ec273b2