### PR TITLE
feat: add telegram link management in frontend

### DIFF
--- a/frontend/src/components/auth/TelegramLogin.jsx
+++ b/frontend/src/components/auth/TelegramLogin.jsx
@@ -1,46 +1,27 @@
-import React, {useEffect, useRef} from 'react';
+import React from 'react';
 import {useAuth} from "../../contexts/AuthContext";
 import {useNavigate} from "react-router-dom";
+import useTelegramAuth from '../../hooks/useTelegramAuth';
 import './SocialLogin.css';
 
-
-const TelegramLogin = ({telegramBotUsername}) => {
-  const telegramWidgetRef = useRef(null);
+// Reusable Telegram authentication widget
+const TelegramLogin = ({telegramBotUsername, onAuth, title = 'Log in to your existing Vacal account with Telegram'}) => {
   const {handleTelegramLogin} = useAuth();
   const navigate = useNavigate();
 
-  useEffect(() => {
-    // Define the onTelegramAuth function
-    window.onTelegramAuth = async (user) => {
-      const result = await handleTelegramLogin(user);
-      if (result?.success) {
-        navigate('/');
-      }
-    };
+  const defaultOnAuth = async (user) => {
+    const result = await handleTelegramLogin(user);
+    if (result?.success) {
+      navigate('/');
+    }
+  };
 
-    const script = document.createElement('script');
-    script.src = "https://telegram.org/js/telegram-widget.js?22";
-    script.setAttribute('data-telegram-login', telegramBotUsername);
-    script.setAttribute('data-size', "large");
-    script.setAttribute('data-onauth', "onTelegramAuth(user)");
-    script.setAttribute('data-request-access', "write");
-    script.async = true;
-
-    // Append the script to the ref element
-    telegramWidgetRef.current.appendChild(script);
-
-    return () => {
-      if (telegramWidgetRef.current) {
-        telegramWidgetRef.current.removeChild(script);
-      }
-      delete window.onTelegramAuth;
-    };
-  }, []);
+  const widgetRef = useTelegramAuth(telegramBotUsername, onAuth || defaultOnAuth);
 
   return (
     <div className="socialLoginContainer">
-      <h3>Log in to your existing Vacal account with Telegram</h3>
-      <div ref={telegramWidgetRef}></div>
+      <h3>{title}</h3>
+      <div ref={widgetRef}></div>
     </div>
   );
 };

--- a/frontend/src/hooks/useTelegramAuth.js
+++ b/frontend/src/hooks/useTelegramAuth.js
@@ -1,0 +1,38 @@
+import {useEffect, useRef} from 'react';
+
+// Hook to embed Telegram login widget and handle authentication callback
+const useTelegramAuth = (telegramBotUsername, onAuth) => {
+  const widgetRef = useRef(null);
+
+  useEffect(() => {
+    if (!telegramBotUsername) return;
+    // Set global callback expected by Telegram login widget
+    window.onTelegramAuth = async (user) => {
+      try {
+        await onAuth(user);
+      } finally {
+        delete window.onTelegramAuth;
+      }
+    };
+
+    const script = document.createElement('script');
+    script.src = 'https://telegram.org/js/telegram-widget.js?22';
+    script.setAttribute('data-telegram-login', telegramBotUsername);
+    script.setAttribute('data-size', 'large');
+    script.setAttribute('data-onauth', 'onTelegramAuth(user)');
+    script.setAttribute('data-request-access', 'write');
+    script.async = true;
+    widgetRef.current.appendChild(script);
+
+    return () => {
+      if (widgetRef.current) {
+        widgetRef.current.innerHTML = '';
+      }
+      delete window.onTelegramAuth;
+    };
+  }, [telegramBotUsername, onAuth]);
+
+  return widgetRef;
+};
+
+export default useTelegramAuth;


### PR DESCRIPTION
## Summary
- reuse Telegram login widget with new `useTelegramAuth` hook
- allow account link/unlink from user management using a modal
- support customizable Telegram login component for multiple flows

## Testing
- `cd frontend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b07b32235483208ab9f9d6be8d8dc9