### PR TITLE
Add hourly notifications for new absence audits

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -27,6 +27,7 @@ from .scheduled.activate_trials import activate_trials
 from .scheduled.birthdays import send_birthday_email_updates
 from .scheduled.update_max_team_members_numbers import run_update_max_team_members_numbers
 from .scheduled.absence_starts import send_absence_email_updates, send_upcoming_absence_email_updates
+from .scheduled.day_audit_notifications import send_recent_absence_notifications
 
 origins = [
     "http://localhost",
@@ -51,6 +52,7 @@ MULTITENANCY_ENABLED = os.getenv("MULTITENANCY_ENABLED", False)
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     scheduler = BackgroundScheduler()
+    scheduler.add_job(send_recent_absence_notifications, 'cron', minute=0)
     scheduler.add_job(send_absence_email_updates, 'cron', hour=6, minute=0)
     scheduler.add_job(send_upcoming_absence_email_updates, 'cron', hour=6, minute=1)
     scheduler.add_job(send_birthday_email_updates, 'cron', hour=6, minute=5)

--- a/backend/scheduled/day_audit_notifications.py
+++ b/backend/scheduled/day_audit_notifications.py
@@ -1,0 +1,157 @@
+import datetime
+import logging
+import os
+from collections import defaultdict
+from typing import Dict, Iterable, List
+
+from ..email_service import send_email
+from ..model import DayAudit, Team
+
+log = logging.getLogger(__name__)
+
+cors_origin = os.getenv("CORS_ORIGIN")  # should contain production domain of the frontend
+
+
+def _normalize_now(now: datetime.datetime | None) -> datetime.datetime:
+    if now is None:
+        return datetime.datetime.now(datetime.timezone.utc)
+    if now.tzinfo is None:
+        return now.replace(tzinfo=datetime.timezone.utc)
+    return now.astimezone(datetime.timezone.utc)
+
+
+def _get_time_window(now: datetime.datetime | None) -> tuple[datetime.datetime, datetime.datetime]:
+    normalized_now = _normalize_now(now)
+    current_hour_start = normalized_now.replace(minute=0, second=0, microsecond=0)
+    previous_hour_start = current_hour_start - datetime.timedelta(hours=1)
+    window_start = previous_hour_start - datetime.timedelta(hours=1)
+    return window_start, previous_hour_start
+
+
+def _get_added_absence_day_types(audit: DayAudit) -> List:
+    old_absence_ids = {str(day_type.id) for day_type in audit.old_day_types if getattr(day_type, "is_absence", False)}
+    added_absence_day_types = []
+    for day_type in audit.new_day_types:
+        if not getattr(day_type, "is_absence", False):
+            continue
+        if str(day_type.id) not in old_absence_ids:
+            added_absence_day_types.append(day_type)
+    return added_absence_day_types
+
+
+def _get_member_by_uid(team: Team, member_uid: str):
+    for member in team.team_members:
+        if str(member.uid) == member_uid:
+            return member
+    return None
+
+
+def _get_actor_name(audit: DayAudit) -> str | None:
+    user = audit.user
+    if not user:
+        return None
+    if getattr(user, "name", None):
+        return user.name
+    if getattr(user, "email", None):
+        return user.email
+    auth_details = getattr(user, "auth_details", None)
+    if auth_details and getattr(auth_details, "username", None):
+        return auth_details.username
+    return None
+
+
+def _collect_notifications(
+    audits: Iterable[DayAudit],
+) -> Dict[str, Dict[str, List[dict]]]:
+    notifications = defaultdict(lambda: defaultdict(list))
+    for audit in audits:
+        added_absence_day_types = _get_added_absence_day_types(audit)
+        if not added_absence_day_types:
+            continue
+        team = audit.team
+        if team is None:
+            continue
+        member = _get_member_by_uid(team, audit.member_uid)
+        if member is None:
+            continue
+        entry = {
+            "member_name": member.name,
+            "date": audit.date,
+            "day_types": [day_type.name for day_type in added_absence_day_types],
+            "added_by": _get_actor_name(audit),
+            "comment": (audit.new_comment or "").strip(),
+        }
+        for subscriber in team.subscribers:
+            if subscriber.email:
+                notifications[subscriber.email][team.name].append(entry)
+    return notifications
+
+
+def _format_notification_line(entry: dict) -> str:
+    day_types = ", ".join(entry["day_types"])
+    line = f"- {entry['member_name']} was marked absent with {day_types} on {entry['date'].isoformat()}."
+    if entry.get("added_by"):
+        line += f" Added by {entry['added_by']}."
+    comment = entry.get("comment")
+    if comment:
+        line += f" Comment: {comment}"
+    return line
+
+
+def _generate_email_body(
+    teams_notifications: Dict[str, List[dict]],
+    window_start: datetime.datetime,
+    window_end: datetime.datetime,
+) -> str:
+    if not teams_notifications:
+        return ""
+    window_start_str = window_start.strftime("%B %d, %Y %H:%M")
+    window_end_str = window_end.strftime("%H:%M")
+    body_lines = [
+        "Hello!",
+        "",
+        f"The following absences were added between {window_start_str} and {window_end_str} UTC:",
+        "",
+    ]
+    for team_name, entries in sorted(teams_notifications.items()):
+        body_lines.append(f"{team_name}:")
+        for entry in sorted(entries, key=lambda e: (e["date"], e["member_name"], e["day_types"])):
+            body_lines.append(_format_notification_line(entry))
+        body_lines.append("")
+    destination = cors_origin or "the vacation calendar"
+    body_lines.extend([
+        f"For details, visit {destination}.",
+        "",
+        "Best regards,",
+        "Vacation Calendar",
+    ])
+    return "\n".join(body_lines)
+
+
+def _generate_subject(window_start: datetime.datetime, window_end: datetime.datetime) -> str:
+    return (
+        "New Absences Added - "
+        f"{window_start.strftime('%b %d %H:%M')} - {window_end.strftime('%H:%M')} UTC"
+    )
+
+
+def send_recent_absence_notifications(now: datetime.datetime | None = None) -> None:
+    log.debug("Start scheduled task send_recent_absence_notifications")
+    window_start, window_end = _get_time_window(now)
+    audits = DayAudit.objects(
+        timestamp__gte=window_start,
+        timestamp__lt=window_end,
+    ).select_related()
+
+    notifications = _collect_notifications(audits)
+    if not notifications:
+        log.debug("No new absence audits to notify about")
+        log.debug("Stop scheduled task send_recent_absence_notifications")
+        return
+
+    subject = _generate_subject(window_start, window_end)
+    for email, teams_notifications in notifications.items():
+        body = _generate_email_body(teams_notifications, window_start, window_end)
+        if body:
+            send_email(subject, body, email)
+    log.debug("Stop scheduled task send_recent_absence_notifications")

--- a/backend/tests/scheduled/test_day_audit_notifications.py
+++ b/backend/tests/scheduled/test_day_audit_notifications.py
@@ -1,0 +1,167 @@
+import datetime
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from backend.model import (
+    DayAudit,
+    DayType,
+    Team,
+    TeamMember,
+    Tenant,
+    User,
+    AuthDetails,
+)
+from backend.scheduled.day_audit_notifications import send_recent_absence_notifications
+
+
+@pytest.fixture(autouse=True)
+def clear_collections():
+    DayAudit.drop_collection()
+    Team.drop_collection()
+    Tenant.drop_collection()
+    DayType.drop_collection()
+    User.drop_collection()
+    yield
+    DayAudit.drop_collection()
+    Team.drop_collection()
+    Tenant.drop_collection()
+    DayType.drop_collection()
+    User.drop_collection()
+
+
+def _create_user(name: str, tenant: Tenant) -> User:
+    return User(
+        tenants=[tenant],
+        name=name,
+        email=f"{name.lower().replace(' ', '.')}{uuid.uuid4()}@example.com",
+        auth_details=AuthDetails(username=str(uuid.uuid4())),
+    ).save()
+
+
+def test_send_recent_absence_notifications_dispatch_and_content():
+    now = datetime.datetime(2025, 5, 10, 12, 0, tzinfo=datetime.timezone.utc)
+    tenant = Tenant(name=f"Tenant{uuid.uuid4()}", identifier=str(uuid.uuid4())).save()
+    DayType.init_day_types(tenant)
+    vacation = DayType.objects(tenant=tenant, identifier="vacation").first()
+    compensatory = DayType.objects(tenant=tenant, identifier="compensatory_leave").first()
+
+    subscriber = _create_user("Subscriber", tenant)
+    manager = _create_user("Manager Example", tenant)
+
+    member_alice = TeamMember(name="Alice Example", country="Sweden", email="alice@example.com")
+    member_bob = TeamMember(name="Bob Example", country="Sweden", email="bob@example.com")
+
+    team = Team(
+        tenant=tenant,
+        name="Team Alpha",
+        team_members=[member_alice, member_bob],
+        subscribers=[subscriber],
+    ).save()
+
+    window_start = datetime.datetime(2025, 5, 10, 10, 0, tzinfo=datetime.timezone.utc)
+    DayAudit(
+        tenant=tenant,
+        team=team,
+        member_uid=str(member_alice.uid),
+        date=datetime.date(2025, 5, 12),
+        user=manager,
+        timestamp=window_start + datetime.timedelta(minutes=15),
+        old_day_types=[],
+        new_day_types=[vacation],
+        old_comment="",
+        new_comment="Enjoy your vacation!",
+        action="created",
+    ).save()
+
+    override = DayType.objects(tenant=tenant, identifier="override").first()
+    DayAudit(
+        tenant=tenant,
+        team=team,
+        member_uid=str(member_bob.uid),
+        date=datetime.date(2025, 5, 13),
+        user=manager,
+        timestamp=window_start + datetime.timedelta(minutes=30),
+        old_day_types=[override],
+        new_day_types=[compensatory],
+        old_comment="",
+        new_comment="",
+        action="updated",
+    ).save()
+
+    expected_subject = "New Absences Added - May 10 10:00 - 11:00 UTC"
+    expected_body = (
+        "Hello!\n\n"
+        "The following absences were added between May 10, 2025 10:00 and 11:00 UTC:\n\n"
+        "Team Alpha:\n"
+        "- Alice Example was marked absent with Vacation on 2025-05-12. Added by Manager Example. Comment: Enjoy your vacation!\n"
+        "- Bob Example was marked absent with Compensatory leave on 2025-05-13. Added by Manager Example.\n\n"
+        "For details, visit https://example.com.\n\n"
+        "Best regards,\n"
+        "Vacation Calendar"
+    )
+
+    with patch("backend.scheduled.day_audit_notifications.send_email") as mock_send_email, \
+         patch("backend.scheduled.day_audit_notifications.cors_origin", "https://example.com"):
+        send_recent_absence_notifications(now=now)
+
+    mock_send_email.assert_called_once_with(
+        expected_subject,
+        expected_body,
+        subscriber.email,
+    )
+
+
+def test_send_recent_absence_notifications_ignores_non_matching_audits():
+    now = datetime.datetime(2025, 5, 10, 12, 0, tzinfo=datetime.timezone.utc)
+    tenant = Tenant(name=f"Tenant{uuid.uuid4()}", identifier=str(uuid.uuid4())).save()
+    DayType.init_day_types(tenant)
+    vacation = DayType.objects(tenant=tenant, identifier="vacation").first()
+
+    subscriber = _create_user("Subscriber", tenant)
+    manager = _create_user("Manager Example", tenant)
+
+    member = TeamMember(name="Charlie Example", country="Sweden", email="charlie@example.com")
+    team = Team(
+        tenant=tenant,
+        name="Team Beta",
+        team_members=[member],
+        subscribers=[subscriber],
+    ).save()
+
+    window_start = datetime.datetime(2025, 5, 10, 10, 0, tzinfo=datetime.timezone.utc)
+    # Timestamp in the immediately preceding hour should be ignored
+    DayAudit(
+        tenant=tenant,
+        team=team,
+        member_uid=str(member.uid),
+        date=datetime.date(2025, 5, 14),
+        user=manager,
+        timestamp=window_start + datetime.timedelta(hours=1, minutes=5),
+        old_day_types=[],
+        new_day_types=[vacation],
+        old_comment="",
+        new_comment="",
+        action="created",
+    ).save()
+
+    # No change in absence day types
+    DayAudit(
+        tenant=tenant,
+        team=team,
+        member_uid=str(member.uid),
+        date=datetime.date(2025, 5, 15),
+        user=manager,
+        timestamp=window_start + datetime.timedelta(minutes=10),
+        old_day_types=[vacation],
+        new_day_types=[vacation],
+        old_comment="Old",
+        new_comment="Updated comment",
+        action="updated",
+    ).save()
+
+    with patch("backend.scheduled.day_audit_notifications.send_email") as mock_send_email:
+        send_recent_absence_notifications(now=now)
+
+    mock_send_email.assert_not_called()


### PR DESCRIPTION
## Summary
- add an hourly background job that emails team subscribers about new absence entries recorded in day audits
- build notification content that summarizes added day types and the acting user
- cover the scheduler helper with targeted tests and ensure previous scheduled tasks continue to pass

## Testing
- pytest tests/scheduled

------
https://chatgpt.com/codex/tasks/task_e_68cbd815fd28832081853c7c22b78621