### PR TITLE
Unify modal form styling across app

### DIFF
--- a/frontend/src/components/settings/DayTypeModal.css
+++ b/frontend/src/components/settings/DayTypeModal.css
@@ -21,16 +21,6 @@
     padding: 0;
 }
 
-.absence-checkbox {
-    display: flex;
-    align-items: center;
-    margin: 10px 0;
-}
-
-.absence-checkbox input {
-    margin-right: 8px;
-}
-
 .button-container {
     display: flex;
     justify-content: space-between;

--- a/frontend/src/components/settings/DayTypeModal.jsx
+++ b/frontend/src/components/settings/DayTypeModal.jsx
@@ -82,14 +82,14 @@ const DayTypeModal = ({ isOpen, onClose, editingDayType }) => {
                             className="color-picker"
                         />
                     </div>
-                    <label className="absence-checkbox">
+                    <label className="form-checkbox">
                         <input
                             type="checkbox"
                             name="is_absence"
                             checked={dayTypeData.is_absence}
                             onChange={handleChange}
                         />
-                        Absence
+                        <span>Absence</span>
                     </label>
                     <div className="button-container">
                         <button type="submit">{editingDayType ? 'Update' : 'Add'} Day Type</button>

--- a/frontend/src/components/settings/UserModal.jsx
+++ b/frontend/src/components/settings/UserModal.jsx
@@ -91,13 +91,13 @@ const UserModal = ({ isOpen, onClose, editingUser }) => {
                             placeholder="Enter Telegram username"
                         />
                     </label>
-                    <label>
-                        Disabled
+                    <label className="form-checkbox">
                         <input
                             type="checkbox"
                             checked={newUserData.disabled}
                             onChange={(e) => setNewUserData({ ...newUserData, disabled: e.target.checked })}
                         />
+                        <span>Disabled</span>
                     </label>
                     {currentUser?.role === 'manager' && (
                         <label>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -21,15 +21,35 @@ form label {
     font-size: 14px;
     display: flex;
     flex-direction: column;
+    gap: 6px;
 }
 
 form label input {
-    margin-top: 2px;
+    margin-top: 0;
 }
 
-form input[type="text"], form input[type="password"], form input[type="email"], form input[type="number"], form input[type="date"], form input[type="tel"] {
+form input[type="text"],
+form input[type="password"],
+form input[type="email"],
+form input[type="number"],
+form input[type="date"],
+form input[type="tel"],
+form select,
+form textarea {
     padding: 8px;
     border-radius: 6px;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+form .form-checkbox {
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+}
+
+form .form-checkbox input[type="checkbox"] {
+    margin: 0;
 }
 
 form button {


### PR DESCRIPTION
## Summary
- move form field alignment rules into the shared stylesheet for consistent styling across pages
- update the user and day type modals to use the shared checkbox presentation

## Testing
- npm test -- --watch=false *(fails: react-scripts not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e02e5449d08320bf2bd7bb59c8b5ca